### PR TITLE
1113: add update note; customize-freshservice

### DIFF
--- a/docs/integration/external-integrations/freshservice-integration/customize-freshservice.mdx
+++ b/docs/integration/external-integrations/freshservice-integration/customize-freshservice.mdx
@@ -12,6 +12,10 @@ This page covers advanced data mapping customization and XML file editing.
 - For usage and operations, see [Using the Freshservice Integration](use-freshservice-integration.mdx).
 :::
 
+If you make an adjustment and use a custom XML file, Device42 will not update the custom XML during updates. 
+
+If you want to incorporate updates, you'll need to do so manually: Download the current XML file, compare it to your customized XML file, and add in the new items as needed.
+
 ## Custom Data Mapping
 
 ### Download the `mapping.xml` File


### PR DESCRIPTION
Original note provided by D42:

> - If the customer makes an adjustment and uses a custom XML, we will not update the custom XML during updates. 
> 
> - If the customer wants to incorporate the updates, they can download the current XML, compare to their customizations and add in the new items as needed.