### PR TITLE
60871: Add Freshservice mapping file downloads and fix release notes sidebar order

### DIFF
--- a/docs/release-notes/freshservice-mapping/_category_.yml
+++ b/docs/release-notes/freshservice-mapping/_category_.yml
@@ -1,4 +1,4 @@
-position: 3
+position: 5
 label: 'Freshservice Mapping'
 collapsible: true
 collapsed: false

--- a/docs/release-notes/freshservice-mapping/_category_.yml
+++ b/docs/release-notes/freshservice-mapping/_category_.yml
@@ -3,7 +3,5 @@ label: 'Freshservice Mapping'
 collapsible: true
 collapsed: false
 link:
-  type: generated-index
-  slug: /release-notes/freshservice-mapping/
-  title: Freshservice Mapping Release Notes
-  description: Changes to the Freshservice mapping file by Cloud Connector version.
+  type: doc
+  id: release-notes/freshservice-mapping/index

--- a/docs/release-notes/freshservice-mapping/index.mdx
+++ b/docs/release-notes/freshservice-mapping/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Download Mapping Files"
+title: "Freshservice Mapping Release Notes"
+slug: /release-notes/freshservice-mapping/
 sidebar_position: 0
-description: Download the Freshservice mapping.xml file for each Cloud Connector version.
 ---
 
 Each Freshservice Cloud Connector release ships with a `mapping.xml` file that defines how Device42 data is copied to Freshservice. Use the links below to download the mapping file for a specific version.

--- a/docs/release-notes/freshservice-mapping/mapping-downloads.mdx
+++ b/docs/release-notes/freshservice-mapping/mapping-downloads.mdx
@@ -1,0 +1,21 @@
+---
+title: "Download Mapping Files"
+sidebar_position: 0
+description: Download the Freshservice mapping.xml file for each Cloud Connector version.
+---
+
+Each Freshservice Cloud Connector release ships with a `mapping.xml` file that defines how Device42 data is copied to Freshservice. Use the links below to download the mapping file for a specific version.
+
+To see what changed between versions, open the corresponding **Changes in Version** page in this section.
+
+## Mapping File Downloads
+
+- <a href="/assets/files/mapping-9.xml" download>Version 9.0 (CC 5.5.0)</a>
+- <a href="/assets/files/mapping-8.xml" download>Version 8.0 (CC 5.4.0)</a>
+- <a href="/assets/files/mapping-7.xml" download>Version 7.0 (CC 5.3.0)</a>
+- <a href="/assets/files/mapping-6.xml" download>Version 6.0 (CC 5.2.0)</a>
+- <a href="/assets/files/mapping-5.xml" download>Version 5.0 (CC 5.1.2)</a>
+- <a href="/assets/files/mapping-4.xml" download>Version 4.0 (CC 5.1.0)</a>
+- <a href="/assets/files/mapping-3.xml" download>Version 3.0 (CC 5.0.0)</a>
+- <a href="/assets/files/mapping-2.xml" download>Version 2.0</a>
+- <a href="/assets/files/mapping-1.xml" download>Version 1.0</a>

--- a/static/assets/files/mapping-1.xml
+++ b/static/assets/files/mapping-1.xml
@@ -1,0 +1,6009 @@
+<meta version="1.0">
+    <tasks>
+        <task enable="true" name="Products" type="product" description="Copy Product info from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target asset-type="Hardware"/>
+                <resource
+                          doql="
+                            select distinct
+                                view_vendor_v1.name as manufacturer,
+                                case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as name
+                                from view_device_v2 left join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                left join view_vendor_v1 on vendor_pk=vendor_fk
+                            "
+                        />
+            </api>
+            <mapping key="name" doql-suffix=" where GREATEST(view_hardware_v2.last_changed, view_vendor_v1.last_changed, view_device_v2.last_changed) >'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="manufacturer" source-type="string" target="manufacturer" target-type="string"
+                   not-null="true" set-space="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Products" type="product" description="Copy Product info from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target asset-type="Hardware"/>
+                <resource
+                          doql="
+                            select distinct
+                                view_vendor_v1.name as manufacturer,
+                                case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as name
+                                from view_device_v1 left join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1 on vendor_pk=vendor_fk
+                            "
+                        />
+            </api>
+            <mapping key="name" doql-suffix=" where GREATEST(view_hardware_v1.last_changed, view_vendor_v1.last_changed, view_device_v1.last_changed) >'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="manufacturer" source-type="string" target="manufacturer" target-type="string"
+                   not-null="true" set-space="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*, (select email from view_enduser_v1 enduser where enduser.details->>'sid' = sub.sid limit 1) as enduser_email  FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    view_device_v2.last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    case when devicelastlogin.enduser_email is not null then devicelastlogin.enduser_email
+                                          else devicelastlogin.username end as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  view_device_v2.details->>'used by' AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="products" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" skip-if-null="true" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image" not-null="true"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host" not-null="true"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" not-null="true" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    view_device_v2.last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    view_device_v2.details->>'used by' AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="products" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="products" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" not-null="true" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                       not-null="true"/>
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB" not-null="true"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC" not-null="true"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC" not-null="true"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database" not-null="true"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" not-null="true" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database" not-null="true"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" not-null="true" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription" not-null="true"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk" not-null="true"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair" not-null="true"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair" not-null="true"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage" not-null="true"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC" not-null="true"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC" not-null="true"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC" not-null="true"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC" not-null="true"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk" not-null="true"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group" not-null="true"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group" not-null="true"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores * pm.threads)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null 
+                                   and pt.details ->> 'input_name' is not null and pt.details ->> 'input_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null 
+                                   and pt.details ->> 'output_name' is not null and pt.details ->> 'output_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null 
+                                   and pt.details ->> 'marker_name' is not null and pt.details ->> 'marker_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and dev.details->>'fw_device_type' IN ('Switch', 'Router', 'Firewall', 'Router', 'Access Point') 
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true " set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.details ->> 'mac_address'               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(netport.vendor_custom_fields -> 'Name', netport.port)            AS name,
+              netport.port                                                              AS item_id,
+              netport.details ->> 'private_ip'                                          AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ')
+                                                                                        AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')
+                                                                                        AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" not-null="true" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General" not-null="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <!-- There is a known issue reported to FS, the following field types are swapped -->
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image" skip-if-null="true"/>
+         </mapping>
+     </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool" not-null="true"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network" not-null="true"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.details ->> 'uuid'                                                        AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Disk' and resource.details ->> 'uuid' is not null
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore" not-null="true"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod" skip-if-null="true"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" not-null="true" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set" skip-if-null="true"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job" skip-if-null="true"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                select distinct
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', sc.client_device_fk) as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   d2.name as dependency_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-2.xml
+++ b/static/assets/files/mapping-2.xml
@@ -1,0 +1,9481 @@
+<meta version="2.0">
+    <tasks>
+        <task enable="true" name="Products" type="product" description="Copy Product info from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target asset-type="Hardware"/>
+                <resource
+                          doql="
+                            select distinct
+                                view_vendor_v1.name as manufacturer,
+                                case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as name
+                                from view_device_v2 left join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                left join view_vendor_v1 on vendor_pk=vendor_fk
+                            "
+                        />
+            </api>
+            <mapping key="name" doql-suffix=" where GREATEST(view_hardware_v2.last_changed, view_vendor_v1.last_changed, view_device_v2.last_changed) >'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="manufacturer" source-type="string" target="manufacturer" target-type="string"
+                   not-null="true" set-space="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Products" type="product" description="Copy Product info from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target asset-type="Hardware"/>
+                <resource
+                          doql="
+                            select distinct
+                                view_vendor_v1.name as manufacturer,
+                                case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as name
+                                from view_device_v1 left join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1 on vendor_pk=vendor_fk
+                            "
+                        />
+            </api>
+            <mapping key="name" doql-suffix=" where GREATEST(view_hardware_v1.last_changed, view_vendor_v1.last_changed, view_device_v1.last_changed) >'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="manufacturer" source-type="string" target="manufacturer" target-type="string"
+                   not-null="true" set-space="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*, (select email from view_enduser_v1 enduser where enduser.details->>'sid' = sub.sid limit 1) as enduser_email  FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    case when devicelastlogin.enduser_email is not null then devicelastlogin.enduser_email
+                                          else devicelastlogin.username end as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="products" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" skip-if-null="true" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image" not-null="true"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host" not-null="true"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" not-null="true" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="products" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="products" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" not-null="true" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                       not-null="true"/>
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB" not-null="true"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC" not-null="true"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC" not-null="true"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database" not-null="true"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" not-null="true" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database" not-null="true"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" not-null="true" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription" not-null="true"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk" not-null="true"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair" not-null="true"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair" not-null="true"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage" not-null="true"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC" not-null="true"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC" not-null="true"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC" not-null="true"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC" not-null="true"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk" not-null="true"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group" not-null="true"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group" not-null="true"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores * pm.threads)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null 
+                                   and pt.details ->> 'input_name' is not null and pt.details ->> 'input_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null 
+                                   and pt.details ->> 'output_name' is not null and pt.details ->> 'output_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null 
+                                   and pt.details ->> 'marker_name' is not null and pt.details ->> 'marker_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and dev.details->>'fw_device_type' IN ('Switch', 'Router', 'Firewall', 'Router', 'Access Point') 
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true " set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.details ->> 'mac_address'               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" not-null="true" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General" not-null="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <!-- There is a known issue reported to FS, the following field types are swapped -->
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image" skip-if-null="true"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool" not-null="true"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network" not-null="true"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.details ->> 'uuid'                                                        AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Disk' and resource.details ->> 'uuid' is not null
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore" not-null="true"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod" skip-if-null="true"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" not-null="true" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set" skip-if-null="true"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job" skip-if-null="true"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                                     AS network_device42_id,
+                                   COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                          AS ip_name,
+                                   format('IP-%s', ip.ipaddress_pk)                                             AS ip_device42_id
+                            FROM
+                                   view_ipaddress_v2 ip
+                            INNER JOIN 
+                                   view_netport_v1 network on network.port = ip.details ->> 'network_interface_id' 
+                            LEFT JOIN
+                                   view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE ip.is_public = true and infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                select distinct
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', sc.client_device_fk) as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   d2.name as dependency_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     SELECT DISTINCT d1.NAME                                  AS dependent_device_name,
+                                   Format('Device-%s', sc.client_device_fk)   AS dependent_device_device42_id,
+                                   'Connected to'                             AS downstream_relationship,
+                                   d2.NAME                                    AS dependency_device_name,
+                                   Format('Device-%s', sc.listener_device_fk) AS dependency_device_device42_id,
+                                   'Connected to'                             AS upstream_relationship
+                     FROM            view_servicecommunication_v2 sc
+                     INNER JOIN      view_device_v1 d1
+                     ON              sc.client_device_fk = d1.device_pk
+                     INNER JOIN      view_device_v1 d2
+                     ON              sc.listener_device_fk = d2.device_pk
+                     WHERE           (Now() - sc.last_updated) &lt;= interval '30 days'
+                     AND             client_device_fk IS NOT NULL
+                     AND             listener_device_fk IS NOT NULL
+                     AND             client_device_fk &lt;&gt; listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     
+                            COALESCE(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port) AS dependent_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))            AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                               AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     INNER JOIN view_netport_v1 network
+                     ON         network.port = ip.details ->> 'network_interface_id'
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      ip.is_public = true
+                     AND        infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = ANY(ip.device_fks)
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT
+                           coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)   AS dependent_device_name,
+                           format('Netport-%s', netport.netport_pk)                         AS dependent_device_device42_id,
+                           'Has'                                                            AS downstream_relationship,
+                           ip.details ->> 'name'                                            AS dependency_device_name,
+                           format('IP-%s', ip.ipaddress_pk)                                AS dependency_device_device42_id,
+                           'Is Attached To'                                                 AS upstream_relationship
+                    FROM
+                           view_ipaddress_v2 ip
+                    INNER JOIN
+                           view_netport_v1 netport on netport.port = ip.details ->> 'port'
+                           AND netport.details ->> 'nat_ip' = host(ip.ip_address)
+                    LEFT JOIN
+                           view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                           view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE infra.account_id is not null and ip.is_public = TRUE and vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            datastore.resource_name                          AS dependency_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            network.resource_name                            AS dependency_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-3.xml
+++ b/static/assets/files/mapping-3.xml
@@ -1,0 +1,9444 @@
+<meta version="3.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*, (select email from view_enduser_v1 enduser where enduser.details->>'sid' = sub.sid limit 1) as enduser_email  FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    case when devicelastlogin.enduser_email is not null then devicelastlogin.enduser_email
+                                          else devicelastlogin.username end as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" skip-if-null="true" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image" not-null="true"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host" not-null="true"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" not-null="true" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" not-null="true" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                       not-null="true"/>
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB" not-null="true"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC" not-null="true"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC" not-null="true"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database" not-null="true"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" not-null="true" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database" not-null="true"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" not-null="true" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription" not-null="true"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk" not-null="true"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair" not-null="true"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair" not-null="true"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage" not-null="true"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC" not-null="true"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC" not-null="true"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC" not-null="true"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC" not-null="true"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk" not-null="true"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group" not-null="true"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group" not-null="true"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores * pm.threads)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null 
+                                   and pt.details ->> 'input_name' is not null and pt.details ->> 'input_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null 
+                                   and pt.details ->> 'output_name' is not null and pt.details ->> 'output_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null 
+                                   and pt.details ->> 'marker_name' is not null and pt.details ->> 'marker_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and dev.details->>'fw_device_type' IN ('Switch', 'Router', 'Firewall', 'Router', 'Access Point') 
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true " set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.details ->> 'mac_address'               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" not-null="true" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General" not-null="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <!-- There is a known issue reported to FS, the following field types are swapped -->
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image" skip-if-null="true"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool" not-null="true"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network" not-null="true"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.details ->> 'uuid'                                                        AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Disk' and resource.details ->> 'uuid' is not null
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore" not-null="true"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod" skip-if-null="true"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" not-null="true" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set" skip-if-null="true"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job" skip-if-null="true"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                                     AS network_device42_id,
+                                   COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                          AS ip_name,
+                                   format('IP-%s', ip.ipaddress_pk)                                             AS ip_device42_id
+                            FROM
+                                   view_ipaddress_v2 ip
+                            INNER JOIN 
+                                   view_netport_v1 network on network.port = ip.details ->> 'network_interface_id' 
+                            LEFT JOIN
+                                   view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE ip.is_public = true and infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                select distinct
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', sc.client_device_fk) as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   d2.name as dependency_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     SELECT DISTINCT d1.NAME                                  AS dependent_device_name,
+                                   Format('Device-%s', sc.client_device_fk)   AS dependent_device_device42_id,
+                                   'Connected to'                             AS downstream_relationship,
+                                   d2.NAME                                    AS dependency_device_name,
+                                   Format('Device-%s', sc.listener_device_fk) AS dependency_device_device42_id,
+                                   'Connected to'                             AS upstream_relationship
+                     FROM            view_servicecommunication_v2 sc
+                     INNER JOIN      view_device_v1 d1
+                     ON              sc.client_device_fk = d1.device_pk
+                     INNER JOIN      view_device_v1 d2
+                     ON              sc.listener_device_fk = d2.device_pk
+                     WHERE           (Now() - sc.last_updated) &lt;= interval '30 days'
+                     AND             client_device_fk IS NOT NULL
+                     AND             listener_device_fk IS NOT NULL
+                     AND             client_device_fk &lt;&gt; listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     
+                            COALESCE(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port) AS dependent_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))            AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                               AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     INNER JOIN view_netport_v1 network
+                     ON         network.port = ip.details ->> 'network_interface_id'
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      ip.is_public = true
+                     AND        infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = ANY(ip.device_fks)
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT
+                           coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)   AS dependent_device_name,
+                           format('Netport-%s', netport.netport_pk)                         AS dependent_device_device42_id,
+                           'Has'                                                            AS downstream_relationship,
+                           ip.details ->> 'name'                                            AS dependency_device_name,
+                           format('IP-%s', ip.ipaddress_pk)                                AS dependency_device_device42_id,
+                           'Is Attached To'                                                 AS upstream_relationship
+                    FROM
+                           view_ipaddress_v2 ip
+                    INNER JOIN
+                           view_netport_v1 netport on netport.port = ip.details ->> 'port'
+                           AND netport.details ->> 'nat_ip' = host(ip.ip_address)
+                    LEFT JOIN
+                           view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                           view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE infra.account_id is not null and ip.is_public = TRUE and vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            datastore.resource_name                          AS dependency_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            network.resource_name                            AS dependency_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-4.xml
+++ b/static/assets/files/mapping-4.xml
@@ -1,0 +1,9443 @@
+<meta version="4.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*, (select email from view_enduser_v1 enduser where enduser.details->>'sid' = sub.sid limit 1) as enduser_email  FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    case when devicelastlogin.enduser_email is not null then devicelastlogin.enduser_email
+                                          else devicelastlogin.username end as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" skip-if-null="true" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image" not-null="true"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host" not-null="true"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image" not-null="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" not-null="true" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM" not-null="true"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM" not-null="true"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                       not-null="true" skip-if-null="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" not-null="true" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" not-null="true" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" not-null="true"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" not-null="true"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" not-null="true" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" not-null="true" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" not-null="true" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" not-null="true" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" not-null="true"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" not-null="true"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                       not-null="true"
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" not-null="true" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" not-null="true" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" not-null="true"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" not-null="true" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" not-null="true" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" not-null="true"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" not-null="true" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host" not-null="true" set-space="true"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" not-null="true" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" not-null="true"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" not-null="true" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" not-null="true" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" not-null="true" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" not-null="true" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" not-null="true"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" not-null="true" set-space="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" not-null="true"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" not-null="true" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       set-space="true" min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" not-null="true" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" not-null="true" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" not-null="true" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                       not-null="true"/>
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       not-null="true" set-space="true" min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB" not-null="true"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC" not-null="true"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC" not-null="true"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database" not-null="true"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" not-null="true" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database" not-null="true"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database" not-null="true"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database" not-null="true"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS" not-null="true"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS" not-null="true"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk" not-null="true"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" not-null="true"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" not-null="true" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" not-null="true" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription" not-null="true"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription" not-null="true"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume" not-null="true"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk" not-null="true"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk" not-null="true"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk" not-null="true"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair" not-null="true"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair" not-null="true"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage" not-null="true"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket" not-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" not-null="true"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC" not-null="true"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC" not-null="true"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" not-null="true" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" not-null="true"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet" not-null="true"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" not-null="true" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC" not-null="true"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC" not-null="true"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC" not-null="true"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" not-null="true"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" not-null="true"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk" not-null="true"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk" not-null="true"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" skip-if-null="true"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group" not-null="true"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group" not-null="true"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group" not-null="true"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group" not-null="true"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group" not-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores::integer * pm.threads::integer)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       not-null="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null 
+                                   and pt.details ->> 'input_name' is not null and pt.details ->> 'input_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null 
+                                   and pt.details ->> 'output_name' is not null and pt.details ->> 'output_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null 
+                                   and pt.details ->> 'marker_name' is not null and pt.details ->> 'marker_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                       not-null="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                       not-null="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and dev.details->>'fw_device_type' IN ('Switch', 'Router', 'Firewall', 'Router', 'Access Point') 
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       not-null="true" required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       not-null="true" required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB" not-null="true"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB" not-null="true"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB" not-null="true"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true " set-space="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" not-null="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.details ->> 'mac_address'               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" not-null="true"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" not-null="true" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" not-null="true" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface" not-null="true"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" not-null="true" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" not-null="true" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface" not-null="true"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General" not-null="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="string" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image" skip-if-null="true"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image" skip-if-null="true"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" not-null="true"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" not-null="true"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" skip-if-null="true"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" skip-if-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image" skip-if-null="true"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" not-null="true" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database" not-null="true"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" not-null="true" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool" not-null="true"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network" not-null="true"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network" not-null="true"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.identifier                                                                AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE resource.category @> ARRAY['vmware', 'vdisk', 'vcenter'] AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" not-null="true" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" not-null="true"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" not-null="true"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore" not-null="true"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore" not-null="true"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" not-null="true" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter" not-null="true"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter" not-null="true"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter" not-null="true"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter" not-null="true"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod" skip-if-null="true"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod" skip-if-null="true"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" not-null="true" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set" not-null="true"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set" skip-if-null="true"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set" not-null="true"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job" skip-if-null="true"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job" not-null="true"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" not-null="true" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" not-null="true"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" not-null="true"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address" not-null="true"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address" not-null="true"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" set-space="true" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" not-null="true"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" not-null="true" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" not-null="true" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set" not-null="true"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" not-null="true" set-space="true" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                                     AS network_device42_id,
+                                   COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                          AS ip_name,
+                                   format('IP-%s', ip.ipaddress_pk)                                             AS ip_device42_id
+                            FROM
+                                   view_ipaddress_v2 ip
+                            INNER JOIN 
+                                   view_netport_v1 network on network.port = ip.details ->> 'network_interface_id' 
+                            LEFT JOIN
+                                   view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE ip.is_public = true and infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                select distinct
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', sc.client_device_fk) as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   d2.name as dependency_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     SELECT DISTINCT d1.NAME                                  AS dependent_device_name,
+                                   Format('Device-%s', sc.client_device_fk)   AS dependent_device_device42_id,
+                                   'Connected to'                             AS downstream_relationship,
+                                   d2.NAME                                    AS dependency_device_name,
+                                   Format('Device-%s', sc.listener_device_fk) AS dependency_device_device42_id,
+                                   'Connected to'                             AS upstream_relationship
+                     FROM            view_servicecommunication_v2 sc
+                     INNER JOIN      view_device_v1 d1
+                     ON              sc.client_device_fk = d1.device_pk
+                     INNER JOIN      view_device_v1 d2
+                     ON              sc.listener_device_fk = d2.device_pk
+                     WHERE           (Now() - sc.last_updated) &lt;= interval '30 days'
+                     AND             client_device_fk IS NOT NULL
+                     AND             listener_device_fk IS NOT NULL
+                     AND             client_device_fk &lt;&gt; listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     
+                            COALESCE(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port) AS dependent_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))            AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                               AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     INNER JOIN view_netport_v1 network
+                     ON         network.port = ip.details ->> 'network_interface_id'
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      ip.is_public = true
+                     AND        infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = ANY(ip.device_fks)
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT
+                           coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)   AS dependent_device_name,
+                           format('Netport-%s', netport.netport_pk)                         AS dependent_device_device42_id,
+                           'Has'                                                            AS downstream_relationship,
+                           ip.details ->> 'name'                                            AS dependency_device_name,
+                           format('IP-%s', ip.ipaddress_pk)                                AS dependency_device_device42_id,
+                           'Is Attached To'                                                 AS upstream_relationship
+                    FROM
+                           view_ipaddress_v2 ip
+                    INNER JOIN
+                           view_netport_v1 netport on netport.port = ip.details ->> 'port'
+                           AND netport.details ->> 'nat_ip' = host(ip.ip_address)
+                    LEFT JOIN
+                           view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                           view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE infra.account_id is not null and ip.is_public = TRUE and vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            datastore.resource_name                          AS dependency_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            network.resource_name                            AS dependency_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-5.xml
+++ b/static/assets/files/mapping-5.xml
@@ -1,0 +1,9443 @@
+<meta version="5.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*, (select email from view_enduser_v1 enduser where enduser.details->>'sid' = sub.sid limit 1) as enduser_email  FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    case when devicelastlogin.enduser_email is not null then devicelastlogin.enduser_email
+                                          else devicelastlogin.username end as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                      />
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores::integer * pm.threads::integer)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null 
+                                   and pt.details ->> 'input_name' is not null and pt.details ->> 'input_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null 
+                                   and pt.details ->> 'output_name' is not null and pt.details ->> 'output_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null 
+                                   and pt.details ->> 'marker_name' is not null and pt.details ->> 'marker_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and dev.details->>'fw_device_type' IN ('Switch', 'Router', 'Firewall', 'Router', 'Access Point') 
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true " min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.details ->> 'mac_address'               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="dropdown" target-header="AWS Image"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.identifier                                                                AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE resource.category @> ARRAY['vmware', 'vdisk', 'vcenter'] AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                                     AS network_device42_id,
+                                   COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                          AS ip_name,
+                                   format('IP-%s', ip.ipaddress_pk)                                             AS ip_device42_id
+                            FROM
+                                   view_ipaddress_v2 ip
+                            INNER JOIN 
+                                   view_netport_v1 network on network.port = ip.details ->> 'network_interface_id' 
+                            LEFT JOIN
+                                   view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE ip.is_public = true and infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                select distinct
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', sc.client_device_fk) as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   d2.name as dependency_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     SELECT DISTINCT d1.NAME                                  AS dependent_device_name,
+                                   Format('Device-%s', sc.client_device_fk)   AS dependent_device_device42_id,
+                                   'Connected to'                             AS downstream_relationship,
+                                   d2.NAME                                    AS dependency_device_name,
+                                   Format('Device-%s', sc.listener_device_fk) AS dependency_device_device42_id,
+                                   'Connected to'                             AS upstream_relationship
+                     FROM            view_servicecommunication_v2 sc
+                     INNER JOIN      view_device_v1 d1
+                     ON              sc.client_device_fk = d1.device_pk
+                     INNER JOIN      view_device_v1 d2
+                     ON              sc.listener_device_fk = d2.device_pk
+                     WHERE           (Now() - sc.last_updated) &lt;= interval '30 days'
+                     AND             client_device_fk IS NOT NULL
+                     AND             listener_device_fk IS NOT NULL
+                     AND             client_device_fk &lt;&gt; listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     
+                            COALESCE(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port) AS dependent_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))            AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                               AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     INNER JOIN view_netport_v1 network
+                     ON         network.port = ip.details ->> 'network_interface_id'
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      ip.is_public = true
+                     AND        infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = ANY(ip.device_fks)
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT
+                           coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)   AS dependent_device_name,
+                           format('Netport-%s', netport.netport_pk)                         AS dependent_device_device42_id,
+                           'Has'                                                            AS downstream_relationship,
+                           ip.details ->> 'name'                                            AS dependency_device_name,
+                           format('IP-%s', ip.ipaddress_pk)                                AS dependency_device_device42_id,
+                           'Is Attached To'                                                 AS upstream_relationship
+                    FROM
+                           view_ipaddress_v2 ip
+                    INNER JOIN
+                           view_netport_v1 netport on netport.port = ip.details ->> 'port'
+                           AND netport.details ->> 'nat_ip' = host(ip.ip_address)
+                    LEFT JOIN
+                           view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                           view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE infra.account_id is not null and ip.is_public = TRUE and vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            datastore.resource_name                          AS dependency_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            network.resource_name                            AS dependency_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-6.xml
+++ b/static/assets/files/mapping-6.xml
@@ -1,0 +1,9564 @@
+<meta version="6.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*, (select email from view_enduser_v1 enduser where enduser.details->>'sid' = sub.sid limit 1) as enduser_email  FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    case when devicelastlogin.enduser_email is not null then devicelastlogin.enduser_email
+                                          else devicelastlogin.username end as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT *   FROM sub  WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    devicelastlogin.username as last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                      />
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores::integer * pm.threads::integer)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null 
+                                   and pt.details ->> 'input_name' is not null and pt.details ->> 'input_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null 
+                                   and pt.details ->> 'output_name' is not null and pt.details ->> 'output_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null 
+                                   and pt.details ->> 'marker_name' is not null and pt.details ->> 'marker_type' is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and dev.details->>'fw_device_type' IN ('Switch', 'Router', 'Firewall', 'Router', 'Access Point') 
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true " min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.hwaddress                               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="dropdown" target-header="AWS Image"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to FreshService" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.identifier                                                                AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE resource.category @> ARRAY['vmware', 'vdisk', 'vcenter'] AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to FreshService" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                                     AS network_device42_id,
+                                   COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                          AS ip_name,
+                                   format('IP-%s', ip.ipaddress_pk)                                             AS ip_device42_id
+                            FROM
+                                   view_ipaddress_v2 ip
+                            INNER JOIN 
+                                   view_netport_v1 network on network.port = ip.details ->> 'network_interface_id' 
+                            LEFT JOIN
+                                   view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE ip.is_public = true and infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_min_version="16.19.00">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_max_version="16.18.02">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                select distinct
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', sc.client_device_fk) as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   d2.name as dependency_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     SELECT DISTINCT d1.NAME                                  AS dependent_device_name,
+                                   Format('Device-%s', sc.client_device_fk)   AS dependent_device_device42_id,
+                                   'Connected to'                             AS downstream_relationship,
+                                   d2.NAME                                    AS dependency_device_name,
+                                   Format('Device-%s', sc.listener_device_fk) AS dependency_device_device42_id,
+                                   'Connected to'                             AS upstream_relationship
+                     FROM            view_servicecommunication_v2 sc
+                     INNER JOIN      view_device_v1 d1
+                     ON              sc.client_device_fk = d1.device_pk
+                     INNER JOIN      view_device_v1 d2
+                     ON              sc.listener_device_fk = d2.device_pk
+                     WHERE           (Now() - sc.last_updated) &lt;= interval '30 days'
+                     AND             client_device_fk IS NOT NULL
+                     AND             listener_device_fk IS NOT NULL
+                     AND             client_device_fk &lt;&gt; listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     
+                            COALESCE(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port) AS dependent_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))            AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                               AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     INNER JOIN view_netport_v1 network
+                     ON         network.port = ip.details ->> 'network_interface_id'
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      ip.is_public = true
+                     AND        infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = ANY(ip.device_fks)
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT
+                           coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)   AS dependent_device_name,
+                           format('Netport-%s', netport.netport_pk)                         AS dependent_device_device42_id,
+                           'Has'                                                            AS downstream_relationship,
+                           ip.details ->> 'name'                                            AS dependency_device_name,
+                           format('IP-%s', ip.ipaddress_pk)                                AS dependency_device_device42_id,
+                           'Is Attached To'                                                 AS upstream_relationship
+                    FROM
+                           view_ipaddress_v2 ip
+                    INNER JOIN
+                           view_netport_v1 netport on netport.port = ip.details ->> 'port'
+                           AND netport.details ->> 'nat_ip' = host(ip.ip_address)
+                    LEFT JOIN
+                           view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                           view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE infra.account_id is not null and ip.is_public = TRUE and vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            datastore.resource_name                          AS dependency_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            network.resource_name                            AS dependency_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-7.xml
+++ b/static/assets/files/mapping-7.xml
@@ -1,0 +1,9679 @@
+<meta version="7.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*,
+                                     CASE 
+                                       WHEN sub.sid IS NOT NULL AND sub.sid &lt;&gt; ''
+                                       THEN (
+                                         SELECT enduser.email
+                                         FROM view_enduser_v1 enduser
+                                         WHERE enduser.details ->> 'sid' = sub.sid
+                                         ORDER BY enduser.enduser_pk DESC
+                                         LIMIT 1
+                                       )
+                                       ELSE NULL
+                                     END AS enduser_email
+                                     FROM sub
+                                     WHERE rank = 1 
+                                )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    CASE
+                                     WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                       THEN devicelastlogin.enduser_email
+                                     WHEN devicelastlogin.domain IS NOT NULL
+                                       THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                     ELSE devicelastlogin.username
+                                    END AS last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*,
+                                     (
+                                         SELECT enduser.email
+                                         FROM view_enduser_v1 enduser
+                                         WHERE enduser.name = sub.username
+                                         ORDER BY enduser.enduser_pk DESC
+                                         LIMIT 1
+                                     ) AS enduser_email
+                                    FROM sub
+                                    WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    CASE
+                                      WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                        THEN devicelastlogin.enduser_email
+                                      WHEN devicelastlogin.domain IS NOT NULL
+                                        THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                      ELSE devicelastlogin.username
+                                        END AS last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                   SELECT sub.*,
+                                     (
+                                      SELECT enduser.email
+                                      FROM view_enduser_v1 enduser
+                                      WHERE enduser.name = sub.username
+                                      ORDER BY enduser.enduser_pk DESC
+                                      LIMIT 1
+                                     ) AS enduser_email
+                                    FROM sub
+                                    WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    CASE
+                                      WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                        THEN devicelastlogin.enduser_email
+                                      WHEN devicelastlogin.domain IS NOT NULL
+                                        THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                      ELSE devicelastlogin.username
+                                        END AS last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                      />
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" min-length="1" max-length="255"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" min-length="1" max-length="255"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores::integer * pm.threads::integer)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'input_name'), '') is not null and nullif(trim(pt.details ->> 'input_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'output_name'), '') is not null and nullif(trim(pt.details ->> 'output_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'marker_name'), '') is not null and nullif(trim(pt.details ->> 'marker_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <!--
+                     Below are the rules for determining the device type in the Interface Components task:
+                     1. Check the physical subtype FIRST (highest priority)
+                     2. Check the fw_device_type checks SECOND
+                     3. Check the network_device flag (consistent with Devices task which maps network_device=true to Switch)
+                -->
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and (
+                            (lower(dev.type) = 'physical' AND lower(dev.physicalsubtype) IN ('network printer', 'router', 'firewall', 'access point'))
+                            OR
+                            lower(dev.details->>'fw_device_type') IN ('printer', 'router', 'firewall', 'access point', 'switch')
+                            OR
+                            dev.network_device = true
+                        )
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true " min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.hwaddress                               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="dropdown" target-header="AWS Image"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to Freshservice" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to Freshservice" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.identifier                                                                AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE resource.category @> ARRAY['vmware', 'vdisk', 'vcenter'] AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                                     AS network_device42_id,
+                                   COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                          AS ip_name,
+                                   format('IP-%s', ip.ipaddress_pk)                                             AS ip_device42_id
+                            FROM
+                                   view_ipaddress_v2 ip
+                            INNER JOIN 
+                                   view_netport_v1 network on network.port = ip.details ->> 'network_interface_id' 
+                            LEFT JOIN
+                                   view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE ip.is_public = true and infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_min_version="16.19.00">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_max_version="16.18.02">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							left join view_software_v1 on software_fk=software_pk inner join device on device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                WITH unique_pairs AS MATERIALIZED (
+                                    SELECT DISTINCT client_device_fk, listener_device_fk
+                                    FROM   view_servicecommunication_v2
+                                    WHERE  last_updated &gt;= NOW() - interval '30 days'
+                                    AND    client_device_fk IS NOT NULL
+                                    AND    listener_device_fk IS NOT NULL
+                                    AND    client_device_fk &lt;&gt; listener_device_fk
+                                 )
+                                 SELECT d1.name                                         AS dependent_device_name,
+                                       format('Device-%s', up.client_device_fk)        AS dependent_device_device42_id,
+                                       'Connected to'                                  AS downstream_relationship,
+                                       d2.name                                         AS dependency_device_name,
+                                       format('Device-%s', up.listener_device_fk)      AS dependency_device_device42_id,
+                                       'Connected to'                                  AS upstream_relationship
+                                 FROM   unique_pairs up
+                                 INNER JOIN view_device_v1 d1
+                                       ON d1.device_pk = up.client_device_fk
+                                 INNER JOIN view_device_v1 d2
+                                       ON d2.device_pk = up.listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     WITH unique_pairs AS MATERIALIZED (
+                        SELECT DISTINCT client_device_fk, listener_device_fk
+                        FROM   view_servicecommunication_v2
+                        WHERE  last_updated &gt;= NOW() - interval '30 days'
+                        AND    client_device_fk IS NOT NULL
+                        AND    listener_device_fk IS NOT NULL
+                        AND    client_device_fk &lt;&gt; listener_device_fk
+                     )
+                     SELECT d1.name                                         AS dependent_device_name,
+                           format('Device-%s', up.client_device_fk)        AS dependent_device_device42_id,
+                           'Connected to'                                  AS downstream_relationship,
+                           d2.name                                         AS dependency_device_name,
+                           format('Device-%s', up.listener_device_fk)      AS dependency_device_device42_id,
+                           'Connected to'                                  AS upstream_relationship
+                     FROM   unique_pairs up
+                     INNER JOIN view_device_v1 d1
+                           ON d1.device_pk = up.client_device_fk
+                     INNER JOIN view_device_v1 d2
+                           ON d2.device_pk = up.listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     
+                            COALESCE(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port) AS dependent_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))            AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                               AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     INNER JOIN view_netport_v1 network
+                     ON         network.port = ip.details ->> 'network_interface_id'
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      ip.is_public = true
+                     AND        infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT * FROM (
+                         WITH ms_infra AS MATERIALIZED (
+                            SELECT infra.cloudinfrastructure_pk
+                            FROM   view_cloudinfrastructure_v2 infra
+                            JOIN   view_vendor_v1 vendor
+                                   ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE  vendor.name = 'Microsoft'
+                         ),
+                         all_public_ips AS MATERIALIZED (
+                            SELECT ip.ipaddress_pk,
+                                   ip.ip_address,
+                                   ip.details,
+                                   ip.cloudinfrastructure_fk
+                            FROM   view_ipaddress_v2 ip
+                            WHERE  ip.is_public = true
+                            AND    ip.cloudinfrastructure_fk IS NOT NULL
+                         )
+                         SELECT CASE
+                                   WHEN position('/' IN device.name) > 0
+                                       THEN substring(device.name FROM position('/' IN device.name) + 1)
+                                   ELSE COALESCE(NULLIF(cloud_instance.instance_name, ''), device.name)
+                               END                                                                   AS dependent_device_name,
+                               format('Device-%s', device.device_pk)                                 AS dependent_device_device42_id,
+                               'Has'                                                                 AS downstream_relationship,
+                               COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))   AS dependency_device_name,
+                               format('IP-%s', ip.ipaddress_pk)                                      AS dependency_device_device42_id,
+                               'Is Attached To'                                                      AS upstream_relationship
+                         FROM   all_public_ips ip
+                         INNER JOIN ms_infra mi
+                               ON ip.cloudinfrastructure_fk = mi.cloudinfrastructure_pk
+                         INNER JOIN view_ipaddress_device_v2 ipd
+                               ON ipd.ipaddress_fk = ip.ipaddress_pk
+                         INNER JOIN view_device_v1 device
+                               ON device.device_pk = ipd.device_fk
+                         INNER JOIN view_cloudinstance_v1 cloud_instance
+                               ON cloud_instance.device_fk = device.device_pk
+                     )
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT * FROM (
+                        WITH public_ips AS MATERIALIZED (
+                            SELECT
+                                ip.ipaddress_pk,
+                                ip.details ->> 'name' AS ip_name,
+                                ip.details ->> 'port' AS port_id,
+                                host(ip.ip_address) AS ip_host
+                            FROM view_ipaddress_v2 ip
+                            WHERE ip.is_public = TRUE
+                        ),
+                        google_netports AS MATERIALIZED (
+                            SELECT
+                                netport.netport_pk,
+                                netport.port,
+                                netport.details ->> 'nat_ip' AS nat_ip,
+                                coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS display_name
+                            FROM view_netport_v1 netport
+                            JOIN view_cloudinfrastructure_v2 infra
+                                ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            JOIN view_vendor_v1 vendor
+                                ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id IS NOT NULL
+                            AND vendor.name = 'Google'
+                        )
+                        SELECT
+                            np.display_name AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependent_device_device42_id,
+                            'Has' AS downstream_relationship,
+                            ip.ip_name AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk) AS dependency_device_device42_id,
+                            'Is Attached To' AS upstream_relationship
+                        FROM public_ips ip
+                        INNER JOIN google_netports np
+                            ON np.port = ip.port_id
+                            AND np.nat_ip = ip.ip_host
+                    )
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+
+                     SELECT * FROM (
+                         WITH rels AS MATERIALIZED (
+                            SELECT from_resource_fk, to_resource_fk
+                            FROM  view_resourcerelationship_v2
+                            WHERE  relation = 'datacenter_datastore'
+                         ),
+                         datacenters AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                         ),
+                         datastores AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'ds', 'vcenter']
+                         )
+                         SELECT dc.resource_name                      AS dependent_device_name,
+                               format('Resource-%s', dc.resource_pk)  AS dependent_device_device42_id,
+                               'Contains'                             AS downstream_relationship,
+                               ds.resource_name                       AS dependency_device_name,
+                               format('Resource-%s', ds.resource_pk)  AS dependency_device_device42_id,
+                               'Contained By'                         AS upstream_relationship
+                         FROM   rels
+                         INNER JOIN datacenters dc ON rels.from_resource_fk = dc.resource_pk
+                         INNER JOIN datastores ds  ON rels.to_resource_fk = ds.resource_pk
+                     )
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+
+                     SELECT * FROM (
+                         WITH rels AS MATERIALIZED (
+                            SELECT from_resource_fk, to_resource_fk
+                            FROM  view_resourcerelationship_v2
+                            WHERE  relation = 'datacenter_network'
+                         ),
+                         datacenters AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                         ),
+                         networks AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'network', 'vcenter']
+                         )
+                         SELECT dc.resource_name                      AS dependent_device_name,
+                               format('Resource-%s', dc.resource_pk)  AS dependent_device_device42_id,
+                               'Contains'                             AS downstream_relationship,
+                               net.resource_name                      AS dependency_device_name,
+                               format('Resource-%s', net.resource_pk) AS dependency_device_device42_id,
+                               'Contained By'                         AS upstream_relationship
+                         FROM   rels
+                         INNER JOIN datacenters dc ON rels.from_resource_fk = dc.resource_pk
+                         INNER JOIN networks net   ON rels.to_resource_fk = net.resource_pk
+                     )
+
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-8.xml
+++ b/static/assets/files/mapping-8.xml
@@ -1,0 +1,9731 @@
+<meta version="8.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*,
+                                     CASE 
+                                       WHEN sub.sid IS NOT NULL AND sub.sid &lt;&gt; ''
+                                       THEN (
+                                         SELECT enduser.email
+                                         FROM view_enduser_v1 enduser
+                                         WHERE enduser.details ->> 'sid' = sub.sid
+                                         ORDER BY enduser.enduser_pk DESC
+                                         LIMIT 1
+                                       )
+                                       ELSE NULL
+                                     END AS enduser_email
+                                     FROM sub
+                                     WHERE rank = 1 
+                                )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    CASE
+                                     WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                       THEN devicelastlogin.enduser_email
+                                     WHEN devicelastlogin.domain IS NOT NULL
+                                       THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                     ELSE devicelastlogin.username
+                                    END AS last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" max-length="255"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" />
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" max-length="255"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" />
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*,
+                                     (
+                                         SELECT enduser.email
+                                         FROM view_enduser_v1 enduser
+                                         WHERE enduser.name = sub.username
+                                         ORDER BY enduser.enduser_pk DESC
+                                         LIMIT 1
+                                     ) AS enduser_email
+                                    FROM sub
+                                    WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus * coalesce(view_device_v2.threads_per_core, 1) as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    CASE
+                                      WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                        THEN devicelastlogin.enduser_email
+                                      WHEN devicelastlogin.domain IS NOT NULL
+                                        THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                      ELSE devicelastlogin.username
+                                        END AS last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string"
+                      />
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" />
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                   SELECT sub.*,
+                                     (
+                                      SELECT enduser.email
+                                      FROM view_enduser_v1 enduser
+                                      WHERE enduser.name = sub.username
+                                      ORDER BY enduser.enduser_pk DESC
+                                      LIMIT 1
+                                     ) AS enduser_email
+                                    FROM sub
+                                    WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    CASE
+                                      WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                        THEN devicelastlogin.enduser_email
+                                      WHEN devicelastlogin.domain IS NOT NULL
+                                        THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                      ELSE devicelastlogin.username
+                                        END AS last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255"
+                />
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" />
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" />
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Topology Device To Device Relationships" type="asset_relationship" description="Create Relationship from Service Communication">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', sc.client_device_fk) as client_device_device42_id,
+                                   d1.name as client_device_name,
+                                   format('Device-%s', sc.listener_device_fk) as listener_device_device42_id,
+                                   d2.name as listener_device_name
+                                from view_servicecommunication_v2 sc 
+                                inner join view_device_v1 d1 on sc.client_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on sc.listener_device_fk = d2.device_pk
+                                where (now() - sc.last_updated) &lt;= interval '30 days' 
+                                   and client_device_fk is not null 
+                                   and listener_device_fk is not null
+                                   and client_device_fk &lt;&gt; listener_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="client_device_device42_id"/>
+                <source-2 device42-id="listener_device_device42_id"/>
+            </matching>
+            <mapping key="client_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="listener_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true" />
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" />
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" />
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true"/>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true"/>
+                <field resource="start_date" source-type="string" target="start_date" />
+                <field resource="end_date" source-type="string" target="end_date" />
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count"
+                      />
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       min-length="1" max-length="60000"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" min-length="1" max-length="255"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" min-length="1" max-length="255"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" min-length="1" max-length="255"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" />
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" min-length="1" max-length="255"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" min-length="1" max-length="255"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Security Group" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" min-length="1" max-length="248" escape="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" error-skip="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" min-length="1" max-length="255"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" />
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" />
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" min-length="1" max-length="255"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" min-length="1" max-length="255"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" min-length="1" max-length="255"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" min-length="1" max-length="255"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores::integer * pm.threads::integer)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       min-length="1" max-length="255"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'input_name'), '') is not null and nullif(trim(pt.details ->> 'input_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'output_name'), '') is not null and nullif(trim(pt.details ->> 'output_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'marker_name'), '') is not null and nullif(trim(pt.details ->> 'marker_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer"
+                      />
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer"
+                      />
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <!--
+                     Below are the rules for determining the device type in the Interface Components task:
+                     1. Check the physical subtype FIRST (highest priority)
+                     2. Check the fw_device_type checks SECOND
+                     3. Check the network_device flag (consistent with Devices task which maps network_device=true to Switch)
+                -->
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and (
+                            (lower(dev.type) = 'physical' AND lower(dev.physicalsubtype) IN ('network printer', 'router', 'firewall', 'access point'))
+                            OR
+                            lower(dev.details->>'fw_device_type') IN ('printer', 'router', 'firewall', 'access point', 'switch')
+                            OR
+                            dev.network_device = true
+                        )
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       required="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" min-length="1" max-length="255"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true " min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" min-length="1" max-length="255"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" min-length="1" max-length="255"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.hwaddress                               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" />
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" min-length="1" max-length="255"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="description" source-type="string" target="description" target-header="General"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="string" target-header="AWS Image"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="dropdown" target-header="AWS Image"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to Freshservice" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to Freshservice" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" min-length="1" max-length="255"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" min-length="1" max-length="255"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" />
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" min-length="1" max-length="248" escape="true"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.identifier                                                                AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE resource.category @> ARRAY['vmware', 'vdisk', 'vcenter'] AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" error-skip="true"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" min-length="1" max-length="248" escape="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" min-length="1" max-length="255"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" min-length="1" max-length="255"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" min-length="1" max-length="255"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" min-length="1" max-length="255"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" min-length="1" max-length="255"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" error-skip="true"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" min-length="1" max-length="255"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            WITH amazon_infra AS (
+								SELECT infra.cloudinfrastructure_pk
+								FROM view_cloudinfrastructure_v2 infra
+								INNER JOIN view_vendor_v1 vendor
+									ON infra.cloud_vendor_fk = vendor.vendor_pk
+								WHERE vendor.name = 'Amazon'
+								  AND infra.account_id IS NOT NULL
+							),
+							amazon_networks AS (
+								SELECT
+									network.port,
+									network.netport_pk,
+									network.vendor_custom_fields
+								FROM view_netport_v1 network
+								INNER JOIN amazon_infra
+									ON network.cloudinfrastructure_fk = amazon_infra.cloudinfrastructure_pk
+							)
+							SELECT
+								coalesce(NULLIF(an.vendor_custom_fields -> 'Name', ''), an.port) AS network_name,
+								format('Netport-%s', an.netport_pk)                              AS network_device42_id,
+								COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))              AS ip_name,
+								format('IP-%s', ip.ipaddress_pk)                                 AS ip_device42_id
+							FROM view_ipaddress_v2 ip
+							INNER JOIN amazon_networks an
+								ON an.port = ip.details ->> 'network_interface_id'
+							WHERE ip.is_public = true
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(network.vendor_custom_fields -> 'Name', ''), network.port)   AS network_name,
+                    format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                FROM
+                    view_ipaddress_v2 ip
+                INNER JOIN
+                    view_netport_v1 network ON network.port = ip.details ->> 'port'
+                    AND  network.details ->> 'nat_ip' = host(ip.ip_address)
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE
+                    ip.is_public = true
+                    AND infra.account_id is not null
+                    AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_min_version="16.19.00">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_max_version="16.18.02">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                WITH unique_pairs AS MATERIALIZED (
+                                    SELECT DISTINCT client_device_fk, listener_device_fk
+                                    FROM   view_servicecommunication_v2
+                                    WHERE  last_updated &gt;= NOW() - interval '30 days'
+                                    AND    client_device_fk IS NOT NULL
+                                    AND    listener_device_fk IS NOT NULL
+                                    AND    client_device_fk &lt;&gt; listener_device_fk
+                                 )
+                                 SELECT d1.name                                         AS dependent_device_name,
+                                       format('Device-%s', up.client_device_fk)        AS dependent_device_device42_id,
+                                       'Connected to'                                  AS downstream_relationship,
+                                       d2.name                                         AS dependency_device_name,
+                                       format('Device-%s', up.listener_device_fk)      AS dependency_device_device42_id,
+                                       'Connected to'                                  AS upstream_relationship
+                                 FROM   unique_pairs up
+                                 INNER JOIN view_device_v1 d1
+                                       ON d1.device_pk = up.client_device_fk
+                                 INNER JOIN view_device_v1 d2
+                                       ON d2.device_pk = up.listener_device_fk
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     WITH unique_pairs AS MATERIALIZED (
+                        SELECT DISTINCT client_device_fk, listener_device_fk
+                        FROM   view_servicecommunication_v2
+                        WHERE  last_updated &gt;= NOW() - interval '30 days'
+                        AND    client_device_fk IS NOT NULL
+                        AND    listener_device_fk IS NOT NULL
+                        AND    client_device_fk &lt;&gt; listener_device_fk
+                     )
+                     SELECT d1.name                                         AS dependent_device_name,
+                           format('Device-%s', up.client_device_fk)        AS dependent_device_device42_id,
+                           'Connected to'                                  AS downstream_relationship,
+                           d2.name                                         AS dependency_device_name,
+                           format('Device-%s', up.listener_device_fk)      AS dependency_device_device42_id,
+                           'Connected to'                                  AS upstream_relationship
+                     FROM   unique_pairs up
+                     INNER JOIN view_device_v1 d1
+                           ON d1.device_pk = up.client_device_fk
+                     INNER JOIN view_device_v1 d2
+                           ON d2.device_pk = up.listener_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT *
+                        FROM   ( WITH amazon_netports AS MATERIALIZED (
+                                        SELECT network.netport_pk,
+                                               network.port,
+                                               network.vendor_custom_fields
+                                        FROM   view_netport_v1 network
+                                        INNER JOIN view_cloudinfrastructure_v2 infra
+                                            ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                        INNER JOIN view_vendor_v1 vendor
+                                            ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                        WHERE  infra.account_id IS NOT NULL
+                                        AND    vendor.NAME = 'Amazon'
+                                      ),
+                                      public_ip_with_network_id AS MATERIALIZED (
+                                        SELECT ip.ipaddress_pk,
+                                               ip.label,
+                                               ip.ip_address,
+                                               ip.details ->> 'network_interface_id' AS network_interface_id
+                                        FROM   view_ipaddress_v2 ip
+                                        WHERE  ip.is_public = true
+                                        AND    ip.details ->> 'network_interface_id' IS NOT NULL
+                                      )
+                                      SELECT
+                                             COALESCE(NULLIF(anp.vendor_custom_fields -> 'Name', ''), anp.port) AS dependent_device_name,
+                                             format('Netport-%s', anp.netport_pk)                               AS dependent_device_device42_id,
+                                             'Has'                                                               AS downstream_relationship,
+                                             COALESCE(NULLIF(pip.label, ''), host(pip.ip_address))               AS dependency_device_name,
+                                             format('IP-%s', pip.ipaddress_pk)                                   AS dependency_device_device42_id,
+                                             'Is Attached To'                                                    AS upstream_relationship
+                                      FROM   public_ip_with_network_id pip
+                                      INNER JOIN amazon_netports anp
+                                          ON anp.port = pip.network_interface_id
+                               )
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT * FROM (
+                         WITH ms_infra AS MATERIALIZED (
+                            SELECT infra.cloudinfrastructure_pk
+                            FROM   view_cloudinfrastructure_v2 infra
+                            JOIN   view_vendor_v1 vendor
+                                   ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE  vendor.name = 'Microsoft'
+                         ),
+                         all_public_ips AS MATERIALIZED (
+                            SELECT ip.ipaddress_pk,
+                                   ip.ip_address,
+                                   ip.details,
+                                   ip.cloudinfrastructure_fk
+                            FROM   view_ipaddress_v2 ip
+                            WHERE  ip.is_public = true
+                            AND    ip.cloudinfrastructure_fk IS NOT NULL
+                         )
+                         SELECT CASE
+                                   WHEN position('/' IN device.name) > 0
+                                       THEN substring(device.name FROM position('/' IN device.name) + 1)
+                                   ELSE COALESCE(NULLIF(cloud_instance.instance_name, ''), device.name)
+                               END                                                                   AS dependent_device_name,
+                               format('Device-%s', device.device_pk)                                 AS dependent_device_device42_id,
+                               'Has'                                                                 AS downstream_relationship,
+                               COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))   AS dependency_device_name,
+                               format('IP-%s', ip.ipaddress_pk)                                      AS dependency_device_device42_id,
+                               'Is Attached To'                                                      AS upstream_relationship
+                         FROM   all_public_ips ip
+                         INNER JOIN ms_infra mi
+                               ON ip.cloudinfrastructure_fk = mi.cloudinfrastructure_pk
+                         INNER JOIN view_ipaddress_device_v2 ipd
+                               ON ipd.ipaddress_fk = ip.ipaddress_pk
+                         INNER JOIN view_device_v1 device
+                               ON device.device_pk = ipd.device_fk
+                         INNER JOIN view_cloudinstance_v1 cloud_instance
+                               ON cloud_instance.device_fk = device.device_pk
+                     )
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT * FROM (
+                        WITH public_ips AS MATERIALIZED (
+                            SELECT
+                                ip.ipaddress_pk,
+                                ip.details ->> 'name' AS ip_name,
+                                ip.details ->> 'port' AS port_id,
+                                host(ip.ip_address) AS ip_host
+                            FROM view_ipaddress_v2 ip
+                            WHERE ip.is_public = TRUE
+                        ),
+                        google_netports AS MATERIALIZED (
+                            SELECT
+                                netport.netport_pk,
+                                netport.port,
+                                netport.details ->> 'nat_ip' AS nat_ip,
+                                coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS display_name
+                            FROM view_netport_v1 netport
+                            JOIN view_cloudinfrastructure_v2 infra
+                                ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            JOIN view_vendor_v1 vendor
+                                ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id IS NOT NULL
+                            AND vendor.name = 'Google'
+                        )
+                        SELECT
+                            np.display_name AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependent_device_device42_id,
+                            'Has' AS downstream_relationship,
+                            ip.ip_name AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk) AS dependency_device_device42_id,
+                            'Is Attached To' AS upstream_relationship
+                        FROM public_ips ip
+                        INNER JOIN google_netports np
+                            ON np.port = ip.port_id
+                            AND np.nat_ip = ip.ip_host
+                    )
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+
+                     SELECT * FROM (
+                         WITH rels AS MATERIALIZED (
+                            SELECT from_resource_fk, to_resource_fk
+                            FROM  view_resourcerelationship_v2
+                            WHERE  relation = 'datacenter_datastore'
+                         ),
+                         datacenters AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                         ),
+                         datastores AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'ds', 'vcenter']
+                         )
+                         SELECT dc.resource_name                      AS dependent_device_name,
+                               format('Resource-%s', dc.resource_pk)  AS dependent_device_device42_id,
+                               'Contains'                             AS downstream_relationship,
+                               ds.resource_name                       AS dependency_device_name,
+                               format('Resource-%s', ds.resource_pk)  AS dependency_device_device42_id,
+                               'Contained By'                         AS upstream_relationship
+                         FROM   rels
+                         INNER JOIN datacenters dc ON rels.from_resource_fk = dc.resource_pk
+                         INNER JOIN datastores ds  ON rels.to_resource_fk = ds.resource_pk
+                     )
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+
+                     SELECT * FROM (
+                         WITH rels AS MATERIALIZED (
+                            SELECT from_resource_fk, to_resource_fk
+                            FROM  view_resourcerelationship_v2
+                            WHERE  relation = 'datacenter_network'
+                         ),
+                         datacenters AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                         ),
+                         networks AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'network', 'vcenter']
+                         )
+                         SELECT dc.resource_name                      AS dependent_device_name,
+                               format('Resource-%s', dc.resource_pk)  AS dependent_device_device42_id,
+                               'Contains'                             AS downstream_relationship,
+                               net.resource_name                      AS dependency_device_name,
+                               format('Resource-%s', net.resource_pk) AS dependency_device_device42_id,
+                               'Contained By'                         AS upstream_relationship
+                         FROM   rels
+                         INNER JOIN datacenters dc ON rels.from_resource_fk = dc.resource_pk
+                         INNER JOIN networks net   ON rels.to_resource_fk = net.resource_pk
+                     )
+
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>

--- a/static/assets/files/mapping-9.xml
+++ b/static/assets/files/mapping-9.xml
@@ -1,0 +1,10059 @@
+<meta version="9.0">
+    <tasks>
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_min_version="19.04.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, dll.sid, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC, dll.devicelastlogin_pk DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*,
+                                     CASE 
+                                       WHEN sub.sid IS NOT NULL AND sub.sid &lt;&gt; ''
+                                       THEN (
+                                         SELECT enduser.email
+                                         FROM view_enduser_v1 enduser
+                                         WHERE enduser.details ->> 'sid' = sub.sid
+                                         ORDER BY enduser.enduser_pk DESC
+                                         LIMIT 1
+                                       )
+                                       ELSE NULL
+                                     END AS enduser_email
+                                     FROM sub
+                                     WHERE rank = 1 
+                                )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                      
+                                )
+
+                                select
+                                view_device_v2.device_pk,
+                                CASE
+	                                WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+	                                     (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+	                                    THEN
+                                            CASE
+                                                WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                    substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                ELSE
+                                                    CASE
+                                                        WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                        ELSE ci.instance_name
+                                                    END
+                                            END
+                                    ELSE
+                                        case
+                                            when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                            else ci.instance_name
+                                        end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                      when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                      else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,  
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') = 'switch' THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    CASE
+                                        WHEN lower(view_device_v2.os_name) LIKE '%windows%' OR lower(view_device_v2.os_name) LIKE '%microsoft%' THEN view_device_v2.os_version_no
+                                        WHEN lower(view_device_v2.os_name) LIKE '%mac%' THEN COALESCE(NULLIF(view_deviceos_v1.discovered_data->>'os_version', ''),view_device_v2.os_version)
+                                        ELSE view_device_v2.os_version
+                                    END AS device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    CASE
+                                     WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                       THEN devicelastlogin.enduser_email
+                                     WHEN devicelastlogin.domain IS NOT NULL
+                                       THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                     ELSE devicelastlogin.username
+                                    END AS last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN ci.details->>'region_name'
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.details->> 'vm_manager_instance_id' IS NULL OR view_device_v2.details->> 'vm_manager_instance_id' = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.details ->> 'vm_manager_instance_id', lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    coalesce(ci.status,
+                                    CASE view_device_v2.details ->> 'power_state'
+                                        WHEN 'poweredOn' THEN 'Running'
+                                        WHEN 'poweredOff' THEN 'Stopped'
+                                        ELSE NULL
+                                    END) as instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    (view_device_v2.details ->> 'ebs_optimized')::boolean AS ebs_optimized,
+                                    view_device_v2.details ->> 'hypervisor' AS aws_hypervisor,
+                                    view_device_v2.details ->> 'iam_instance_profile' AS iam_instance_profile,
+                                    view_device_v2.details ->> 'image_id' AS cloud_image_id,
+                                    case
+                                          WHEN LOWER(view_device_v2.details ->> 'instance_lifecycle') IN ('spot', 'scheduled') THEN view_device_v2.details ->> 'instance_lifecycle'
+                                          ELSE 'normal'
+                                    END AS instance_lifecycle,
+                                    view_device_v2.details ->> 'key_name' AS key_name,
+                                    (view_device_v2.details ->> 'launch_time')::timestamptz AS launch_time,
+                                    (view_device_v2.details ->> 'start_time')::timestamptz AS start_time,
+                                    view_device_v2.details ->> 'monitoring_state' AS monitoring_state,
+                                    view_device_v2.details ->> 'private_dns_name' AS private_dns_name,
+                                    view_device_v2.details ->> 'public_dns_name' AS public_dns_name,
+                                    view_device_v2.details ->> 'security_groups' AS security_groups,
+                                    view_device_v2.details ->> 'subnet_id' AS subnet_id,
+                                    view_device_v2.details ->> 'vpc_id' AS vpc_id,
+                                    view_device_v2.details ->> 'ami_launch_index' AS ami_launch_index,
+                                    view_device_v2.details ->> 'offer' AS offer,
+                                    view_device_v2.details ->> 'publisher' AS publisher,
+                                    view_device_v2.details ->> 'os_disk_name' AS os_disk_name,
+                                    view_device_v2.details ->> 'computer_name' AS computer_name,
+                                    view_device_v2.details ->> 'resource_uri' AS resource_uri,
+                                    view_device_v2.details ->> 'resource_group' AS resource_group,
+                                    view_device_v2.details ->> 'resource_pool' AS resource_pool,
+                                    view_device_v2.details ->> 'resource_type' AS resource_type,
+                                    view_device_v2.details ->> 'sku_name' AS sku_name,
+                                    view_device_v2.details ->> 'sku_tier' AS sku_tier,
+                                    view_device_v2.details ->> 'provisioning_state' AS provisioning_state,
+                                    view_device_v2.details ->> 'creation_timestamp' as creation_timestamp,
+                                    view_device_v2.details ->> 'self_link' as self_link,
+                                    view_device_v2.details ->> 'on_host_maintenance' as on_host_maintenance,
+                                    view_device_v2.details ->> 'automatic_restart' as automatic_restart,
+                                    (view_device_v2.details ->> 'preemptible')::boolean as preemptible,
+                                    (view_device_v2.details ->> 'deletion_protection')::boolean as deletion_protection,
+                                    (view_device_v2.details ->> 'template')::boolean as template,
+                                    view_device_v2.details ->> 'asset_tag' as asset_tag,
+                                    view_device_v2.details ->> 'firmware' as firmware,
+                                    view_device_v2.details ->> 'version' as version,
+                                    view_device_v2.details ->> 'guest_full_name' as guest_full_name,
+                                    view_device_v2.details ->> 'guest_hostname' as guest_hostname,
+                                    view_device_v2.details ->> 'dns_name' as dns_name,
+                                    view_device_v2.details ->> 'connection_state' as connection_state,
+                                    view_device_v2.details ->> 'product_line_id' as product_line_id,
+                                    view_device_v2.details ->> 'product_full_name' as product_full_name,
+                                    (SELECT string_agg(value::text, ', ')
+                                     FROM jsonb_array_elements_text(view_device_v2.details -> 'datastore_names')) AS datastore_names,
+                                    view_device_v2.details ->> 'vm_manager_instance_id' as vm_manager_instance_id,
+                                    view_device_v2.details ->> 'vcenter_os_type' as vcenter_os_type,
+                                    view_device_v2.details ->> 'folder' as folder,
+                                    CASE view_device_v2.details ->> 'start_restricted'
+                                        WHEN 'true' THEN 'Yes'
+                                        WHEN 'false' THEN 'No'
+                                        ELSE NULL
+                                    END AS start_restricted,
+                                    view_device_v2.details ->> 'last_start_timestamp' as last_start_timestamp,
+                                    mount_point.mountpoint as mountpoint,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                  view_device_v2.details ->> 'intune_id' AS intune_id,
+                                  view_device_v2.details ->> 'wsone_id' AS airwatch_id,
+                                  view_device_v2.details ->> 'automox_id' AS automox_id,
+                                  view_device_v2.details ->> 'imei' AS imei,
+                                  EXISTS(
+                                      SELECT 1
+                                      FROM view_discoveryscores_v1 ds
+                                      JOIN view_jobscore_v2 js ON ds.jobscore_fk = js.jobscore_pk
+                                      JOIN view_clouddiscovery_v1 cd ON js.clouddiscovery_fk = cd.clouddiscovery_pk
+                                      WHERE ds.device_fk = view_device_v2.device_pk
+                                        AND cd.cloud_type_id IN (14, 16)
+                                  ) AS is_mdm_device,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN lower(view_device_v2.details ->> 'fw_device_type') in ('printer', 'router', 'firewall', 'access point', 'switch') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                  coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                                LEFT JOIN view_deviceos_v1 on view_device_v2.device_pk = view_deviceos_v1.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+                <field resource="intune_id" source-type="string" target="source_asset_ids" target-field="intune_id" target-type="dict" resource-description="Microsoft Intune device identifier" resource-description-manual="true" target-description="Intune ID" target-description-manual="true"/>
+                <field resource="airwatch_id" source-type="string" target="source_asset_ids" target-field="airwatch_id" target-type="dict" resource-description="VMware AirWatch / Workspace ONE device identifier" resource-description-manual="true" target-description="AirWatch ID" target-description-manual="true"/>
+                <field resource="automox_id" source-type="string" target="source_asset_ids" target-field="automox_id" target-type="dict" resource-description="Automox endpoint management device identifier" resource-description-manual="true" target-description="Automox ID" target-description-manual="true"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255" resource-description="Organizations Custom Asset Number of a Physical Device - This can be entered manually or managed via Asset Number Profiles -Typically used to track inventory on Devices such as Laptops, Mobile Phones, etc with barcode labels -This does not link to the database Assets directly" target-description="Asset Tag"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true" resource-description="Device name in Device42" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000" resource-description="User-Defined Notes against a Device" target-description="Description"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General" resource-description="End-of-life date for the asset" resource-description-manual="true" target-description="End of Life"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true" resource-description="Is the Device In Service?" target-description="Asset State">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255" resource-description="Hardware model name" resource-description-manual="true" target-description="Product"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Product"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true" resource-description="Hardware serial number" resource-description-manual="true" target-description="Serial Number"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" resource-description="Warranty duration in months (derived from purchase orders)" resource-description-manual="true" target-description="Warranty"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Warranty expiration date from the most recent contract" resource-description-manual="true" target-description="Warranty Expiry Date"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Date the asset was acquired or purchased" resource-description-manual="true" target-description="Acquisition Date"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255" resource-description="Network domain the device belongs to" resource-description-manual="true" target-description="Domain"/>
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Date and time the device was last discovered by Device42" resource-description-manual="true" target-description="Last Audit Date"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true" resource-description="Total purchase cost from associated purchase line items" resource-description-manual="true" target-description="Cost" target-description-manual="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255" resource-description="Cloud region where the instance is deployed" resource-description-manual="true" target-description="Region"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" resource-description="Type of device - Examples are: Physical, Virtual, Cluster, or Unknown" target-description="Type"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" resource-description="Name for the Physical Subtype of the Device - such as PDU, Access Point, or Laptop - Additional Values can be manually entered as needed" target-description="Physical Subtype"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" resource-description="Virtual Subtype for Device - such as Internal VM, Azure SQL Server, VMWare, Docker Container, or Amazon Service" target-description="Virtual Subtype"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="UUID"/>
+                <!-- IP Address -->
+                <field resource="private_ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255" resource-description="Primary private IPv4 address" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="public_ip_address" type="string" target="public_address"
+                       target-header="Computer" max-length="255" resource-description="Public-facing IP address of the device" resource-description-manual="true" target-description="Public Address"/>
+                <!-- ~IP Address -->
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Operating system version string" resource-description-manual="true" target-description="OS Version"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="OS service pack or build number" resource-description-manual="true" target-description="OS Service Pack"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Device hostname" resource-description-manual="true" target-description="Hostname"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Username of the last logged-in user" resource-description-manual="true" target-description="Last login by"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" resource-description="CPU clock speed in MHz" resource-description-manual="true" target-description="CPU Speed(GHz)"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer" resource-description="Total CPU cores (cores per CPU x number of CPUs)" resource-description-manual="true" target-description="CPU Core Count"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory(GB)"/>
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" resource-description="Total disk space in GB" resource-description-manual="true" target-description="Disk Space(GB)"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer" resource-description="Current instance state (running, stopped, terminated, etc.)" resource-description-manual="true" target-description="State">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" resource-description="Device name in Device42" resource-description-manual="true" target-description="Item Name"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="The Type of Cloud Instance such as e2-small, Standard_B2ms, t3 xlarge, etc" target-description="Instance Type"/>
+                <field resource="start_time" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                      target-header="Computer" resource-description="Device first-seen or creation timestamp" resource-description-manual="true" target-description="Creation Timestamp"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string" resource-description="Email address of the primary user (last login)" resource-description-manual="true" target-description="Used By" target-description-manual="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255" resource-description="Operating system version string" resource-description-manual="true" target-description="OS Version"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory(GB)"/>
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255" resource-description="Mobile device IMEI number" resource-description-manual="true" target-description="IMEI Number"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true" resource-description="Total purchase cost from associated purchase line items" resource-description-manual="true" target-description="Cost"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the instance is deployed" resource-description-manual="true" target-description="Region"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" resource-description="Date and time the device was last discovered by Device42" resource-description-manual="true" target-description="Last Audit Date"/>
+                <!--  ~Cloud -->
+
+                <!-- Image -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                      target-header="Image" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Image" resource-description="Name of the Cloud Instance" target-description="Item Name"/>
+                <!-- ~Image -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware inventory folder path" resource-description-manual="true" target-description="Folder"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware cluster the host belongs to" resource-description-manual="true" target-description="Cluster"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware datastore mount point or name" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="product_full_name" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware product full name (e.g. VMware ESXi 7.0)" resource-description-manual="true" target-description="Hypervisor"/>
+                <field resource="vcenter_os_type" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255" resource-description="OS type as reported by VMware vCenter" resource-description-manual="true" target-description="OS Type"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="Bios UUID"/>
+                <field resource="serial_no" source-type="string" target="cd_serial_number" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" resource-description="Hardware serial number" resource-description-manual="true" target-description="Serial Number" target-description-manual="true"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Hardware Vendor"/>
+                <field resource="dns_name" source-type="string" target="dns_name" target-type="string"
+                      target-header="VMware VCenter Host" min-length="1" max-length="255" resource-description="DNS name of the resource" resource-description-manual="true" target-description="DNS Name"/>
+                <field resource="connection_state" source-type="string" target="connection_state" target-type="dropdown"
+                       target-header="VMware VCenter Host" resource-description="Connection state (connected, disconnected, etc.)" resource-description-manual="true" target-description="Connection State">
+                    <value-mapping default="Unknown">
+                        <item key="connected" value="Connected"/>
+                        <item key="disconnected" value="Disconnected"/>
+                        <item key="notResponding" value="Not Responding"/>
+                </value-mapping>
+                </field>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="VMware VCenter Host" resource-description="CPU clock speed in MHz" resource-description-manual="true" target-description="CPU Speed (GHz)" target-description-manual="true"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255" resource-description="Identifier Key for VM Manager Reference ID for Device" target-description="MoRef ID"/>
+                <field resource="product_line_id" source-type="string" target="product_line_id" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255" resource-description="VMware product line identifier (e.g. embeddedEsx)" resource-description-manual="true" target-description="Product Line ID"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="template" source-type="boolean" target="template" target-type="boolean"
+                       target-header="VMware VCenter VM" resource-description="Whether this VM is a VMware template" resource-description-manual="true" target-description="Template"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter VM" max-length="255" resource-description="VMware inventory folder path" resource-description-manual="true" target-description="Folder"/>
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VM firmware type (bios or efi)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="Version identifier" resource-description-manual="true" target-description="Version"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VMware guest OS full name" resource-description-manual="true" target-description="Guest Full Name"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="Hostname reported by VMware guest tools" resource-description-manual="true" target-description="Hostname" target-description-manual="true"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="Identifier Key for VM Manager Internal ID for Device" target-description="Instance UUID"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="Identifier Key for VM Manager Reference ID for Device" target-description="MoRef ID"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VMware vCenter instance UUID for the VM" resource-description-manual="true" target-description="VCenter Instance UUID"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter VM" resource-description="Total CPU cores (cores per CPU x number of CPUs)" resource-description-manual="true" target-description="Number of CPU"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VMware resource pool name" resource-description-manual="true" target-description="Resource Group"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter VM" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory Size" target-description-manual="true"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255" resource-description="Comma-separated list of VMware datastore names" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="Bios UUID"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VMware cluster the VM is running on" resource-description-manual="true" target-description="Cluster"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- VMWare VCenter Image -->
+                <field resource="firmware" source-type="string" target="firmware" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="VM firmware type (bios or efi)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="folder" type="string" target="folder"
+                       target-header="VMware VCenter Image" max-length="255" resource-description="VMware inventory folder path" resource-description-manual="true" target-description="Folder"/>
+                <field resource="version" source-type="string" target="version" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="Version identifier" resource-description-manual="true" target-description="Version"/>
+                <field resource="guest_full_name" source-type="string" target="guest_full_name" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="VMware guest OS full name" resource-description-manual="true" target-description="Guest Full Name"/>
+                <field resource="guest_hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="Hostname reported by VMware guest tools" resource-description-manual="true" target-description="Hostname"/>
+                <field resource="vm_manager_int_id" source-type="string" target="instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="Identifier Key for VM Manager Internal ID for Device" target-description="Instance UUID"/>
+                <field resource="vm_manager_ref_id" source-type="string" target="moid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="Identifier Key for VM Manager Reference ID for Device" target-description="MoRef ID"/>
+                <field resource="vm_manager_instance_id" source-type="string" target="vcenter_instance_uuid" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="VMware vCenter instance UUID for the VM" resource-description-manual="true" target-description="VCenter Instance UUID"/>
+                <field resource="total_cpucore" source-type="integer" target="num_of_cpu" target-type="integer"
+                       target-header="VMware VCenter Image" resource-description="Total CPU cores (cores per CPU x number of CPUs)" resource-description-manual="true" target-description="Number of CPU"/>
+                <field resource="resource_pool" source-type="string" target="resource_group" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="VMware resource pool name" resource-description-manual="true" target-description="Resource Group"/>
+                <field resource="ramsize" source-type="float" target="memory_size" target-type="float"
+                       target-header="VMware VCenter Image" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory Size(GB)"/>
+                <field resource="datastore_names" type="string" target="datastore"
+                       target-header="VMware VCenter Image" max-length="255" resource-description="Comma-separated list of VMware datastore names" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="uuid" type="string" target="bios_uuid"
+                       target-header="VMware VCenter Image"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="Bios UUID"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter Image" min-length="1" max-length="255" resource-description="VMware cluster the VM is running on" resource-description-manual="true" target-description="Cluster"/>
+                <!-- ~VMWare VCenter Image -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Account ID"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Instance ID"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Identifier Key for Image File of Cloud Instance" target-description="Image Id"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" resource-description="Operating System platform for Cloud Instance (Windows, Canonical, etc)" target-description="Platform"/>
+                <field resource="subnet_id" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Subnet identifier" resource-description-manual="true" target-description="Subnet ID"/>
+                <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="VPC identifier" resource-description-manual="true" target-description="VPC ID"/>
+                <field resource="ebs_optimized" source-type="boolean" target="ebs_optimized" target-type="boolean"
+                       target-header="AWS VM" resource-description="Whether EBS-optimized I/O is enabled" resource-description-manual="true" target-description="EBS Optimized"/>
+                <field resource="aws_hypervisor" source-type="string" target="hypervisor" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="AWS hypervisor type (xen, nitro)" resource-description-manual="true" target-description="Hypervisor"/>
+                <field resource="iam_instance_profile" source-type="string" target="iam_instance_profile" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="IAM instance profile associated with the instance" resource-description-manual="true" target-description="IAM Instance Profile"/>
+                <field resource="instance_lifecycle" source-type="string" target="instance_lifecycle" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Instance lifecycle type (spot, scheduled, or on-demand)" resource-description-manual="true" target-description="Instance Lifecycle"/>
+                <field resource="key_name" source-type="string" target="key_name" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Name of the SSH key pair used for the instance" resource-description-manual="true" target-description="Key Name"/>
+                <field resource="launch_time" source-type="datetime" target="launch_time" target-type="datetime"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Date and time the instance was launched" resource-description-manual="true" target-description="Launch Time"/>
+                <field resource="monitoring_state" source-type="string" target="monitoring_state" target-type="dropdown"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="CloudWatch detailed monitoring state" resource-description-manual="true" target-description="Monitoring State"/>
+                <field resource="private_dns_name" source-type="string" target="private_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255" resource-description="Private DNS hostname within the VPC" resource-description-manual="true" target-description="Private DNS Name"/>
+		            <field resource="public_dns_name" source-type="string" target="public_dns_name"
+                     target-header="AWS VM" min-length="1" max-length="255" resource-description="Public DNS hostname" resource-description-manual="true" target-description="Public DNS Name"/>
+                <field resource="ami_launch_index" source-type="string" target="ami_launch_index" target-type="integer"
+                       target-header="AWS VM" resource-description="Launch index indicating the order the instance was started in" resource-description-manual="true" target-description="AMI Launch Index"/>
+                <field resource="security_groups" source-type="string" target="security_groups"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Comma-separated list of associated security groups" resource-description-manual="true" target-description="Security Groups"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Subscription ID"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Device hostname" resource-description-manual="true" target-description="Computer Name"/>
+                <field resource="offer" source-type="string" target="offer" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Azure Marketplace image offer name" resource-description-manual="true" target-description="Offer"/>
+                <field resource="publisher" source-type="string" target="publisher" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Azure Marketplace image publisher" resource-description-manual="true" target-description="Publisher"/>
+                <field resource="os_disk_name" source-type="string" target="os_disk_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Name of the OS disk attached to the VM" resource-description-manual="true" target-description="OS Disk Name"/>
+                <field resource="os_version" source-type="string" target="sku" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="SKU"/>
+                <field resource="computer_name" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Computer name from the OS profile" resource-description-manual="true" target-description="Computer Name"/>
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Azure resource URI" resource-description-manual="true" target-description="Resource URI"/>
+                <!-- ~Azure VM -->
+
+                <!-- GCP VM -->
+                <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime"
+                       target-header="GCP VM" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+                <field resource="on_host_maintenance" source-type="string" target="on_host_maintenance" target-type="dropdown"
+                       target-header="GCP VM" resource-description="Behavior during host maintenance (MIGRATE or TERMINATE)" resource-description-manual="true" target-description="On Host Maintenance"/>
+                <field resource="automatic_restart" source-type="boolean" target="automatic_restart" target-type="boolean"
+                       target-header="GCP VM" resource-description="Whether the instance automatically restarts on failure" resource-description-manual="true" target-description="Automatic Restart"/>
+                <field resource="preemptible" source-type="boolean" target="preemptible" target-type="boolean"
+                       target-header="GCP VM" resource-description="Whether this is a preemptible (spot) instance" resource-description-manual="true" target-description="Preemptible"/>
+                <field resource="start_restricted" source-type="string" target="start_restricted" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255" resource-description="Whether instance start is restricted by policy" resource-description-manual="true" target-description="Start Restricted"/>
+                <field resource="last_start_timestamp" source-type="datetime" target="last_start_timestamp" target-type="datetime"
+                       target-header="GCP VM" resource-description="Date and time of the last instance start" resource-description-manual="true" target-description="Last Start Timestamp"/>
+                <field resource="self_link" source-type="string" target="self_link" target-type="string"
+                       target-header="GCP VM" min-length="1" max-length="255" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+                <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean"
+                       target-header="GCP VM" resource-description="Whether deletion protection is enabled" resource-description-manual="true" target-description="Deletion Protection"/>
+                <!-- GCP VM -->
+
+                <!-- Azure LB -->
+                <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255" resource-description="Azure resource URI" resource-description-manual="true" target-description="Resource URI"/>
+                <field resource="resource_type" source-type="string" target="resource_type" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+                <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string"
+                        target-header="Azure LB" min-length="1" max-length="255" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+                <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255" resource-description="Azure SKU name" resource-description-manual="true" target-description="SKU Name"/>
+                <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255" resource-description="Azure SKU pricing tier" resource-description-manual="true" target-description="SKU Tier"/>
+                <field resource="resource_group" source-type="string" target="resource_group" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure LB" min-length="1" max-length="255" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Subscription ID"/>
+                <!-- ~Azure LB -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" resource-description="Name of the Cloud Instance" target-description="Item Name"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Switch -->
+              <!-- Kubernetes Node -->
+              <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" resource-description="Kubernetes cluster name the node belongs to" resource-description-manual="true" target-description="Cluster Name"/>
+              <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" resource-description="Kubernetes cluster API server URL for the node" resource-description-manual="true" target-description="Cluster Url"/>
+              <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" resource-description="CPU architecture reported by the Kubernetes node" resource-description-manual="true" target-description="Architecture"/>
+              <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" resource-description="Operating system name reported by the Kubernetes node" resource-description-manual="true" target-description="Operating System"/>
+              <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" resource-description="OS image name reported by the Kubernetes node" resource-description-manual="true" target-description="OS Image"/>
+              <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255" resource-description="Date and time the Kubernetes node was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255" resource-description="Kubernetes resource version for the node" resource-description-manual="true" target-description="Resource Version"/>
+              <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v2" d42_max_version="19.03.99" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                    SELECT sub.*,
+                                     (
+                                         SELECT enduser.email
+                                         FROM view_enduser_v1 enduser
+                                         WHERE enduser.name = sub.username
+                                         ORDER BY enduser.enduser_pk DESC
+                                         LIMIT 1
+                                     ) AS enduser_email
+                                    FROM sub
+                                    WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                    	string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select dr.device_fk, string_agg(resource.resource_name, ', ' order by resource.resource_name) as mountpoint
+                                    from view_deviceresource_v1 dr left join view_resource_v2 resource on resource.resource_pk=dr.resource_fk where dr.relation = 'Mountpoint' group by dr.device_fk)
+                                ,k8s_node_details as (
+                                   select d.device_fk                                     AS device_fk, 
+                                          n.name, 
+                                          c.resource_name                                 AS k8s_cluster_name, 
+                                          c.details->>'endpoint'                          AS k8s_cluster_url, 
+                                          n.architecture                                  AS k8s_architecture,
+                                          n.os_image                                      AS k8s_os_image, 
+                                          (n.create_time)::timestamptz                    AS k8s_creation_timestamp,
+                                          k.details->>'resource_version'                  AS k8s_resource_version,
+                                          n.operating_system                              AS k8s_os_name,
+                                          'AWS K8s Node'                                  AS asset_type,
+                                          format('Resource-%s', n.k8snode_pk)
+                                   from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                          inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                          inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                          inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                          inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                   where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'   
+                                )
+
+                                select
+                                    view_device_v2.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine' OR lower(view_device_v2.virtualsubtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v2.name) > 0 THEN
+                                                        substring(view_device_v2.name FROM position('/' IN view_device_v2.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v2.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v2.serial_no,
+                                    case
+                                        when view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%' then lower(view_device_v2.uuid)
+                                        when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then lower(view_device_v2.uuid)
+                                        else view_device_v2.uuid
+                                    end as uuid,
+                                    view_device_v2.asset_no,
+                                    view_device_v2.in_service,
+                                    view_device_v2.os_name,
+                                    view_device_v2.os_version,
+                                    view_device_v2.datacenter,
+                                    case
+                                          WHEN view_device_v2.details ->> 'intune_id' is not null then coalesce((view_device_v2.details ->> 'last_sync_date_time')::timestamp, view_device_v2.last_discovered)
+                                          ELSE view_device_v2.last_discovered
+                                    end last_discovered,
+                                    view_device_v2.notes,
+                                    view_device_v2.type as device_type,
+                                    view_device_v2.physicalsubtype,
+                                    view_device_v2.virtualsubtype,
+                                    view_device_v2.network_device,
+                                    view_device_v2.blade_chassis,
+                                    view_device_v2.vm_manager_int_id,
+                                    view_device_v2.vm_manager_ref_id,
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN k8snode.asset_type
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v2.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Desktop'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true then 'VMware VCenter Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    coalesce(view_device_v2.physicalsubtype, view_device_v2.virtualsubtype) as device_subtype,
+                                    view_device_v2.core_per_cpu * view_device_v2.total_cpus as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v2.type = 'Virtual' THEN view_device_v2.type WHEN view_device_v2.type = 'Cluster' THEN view_device_v2.type ELSE coalesce(view_hardware_v2.name, view_device_v2.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v2.hz = 'MHz' and view_device_v2.cpu_speed is not null  THEN view_device_v2.cpu_speed / 1000 ELSE view_device_v2.cpu_speed END as cpuspeed,
+                                    case
+                                        WHEN view_device_v2.ram_size_type = 'MB' and view_device_v2.ram is not null  THEN view_device_v2.ram / 1024
+                                        WHEN view_device_v2.ram_size_type = 'TB' and view_device_v2.ram is not null  THEN view_device_v2.ram * 1024
+                                        ELSE view_device_v2.ram END as ramsize,
+                                    network_ip.ip_address,
+                                    network_ip.public_ip_address,
+                                    network_ip.private_ip_address,
+                                    network_ip.subnet_mask,
+                                    network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v2.hard_disk_count IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size IS NOT NULL AND
+                                                             view_device_v2.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'GB' THEN view_device_v2.hard_disk_size
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'TB' THEN view_device_v2.hard_disk_size * 1024
+                                                                    WHEN view_device_v2.hard_disk_size_type = 'PB' THEN view_device_v2.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version_no else view_device_v2.os_version end as device_os_version,
+                                    case when lower(view_device_v2.os_name) like '%windows%' or lower(view_device_v2.os_name) like '%microsoft%' then view_device_v2.os_version else view_device_v2.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v2.name) AS hostname,
+                                    CASE
+                                      WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                        THEN devicelastlogin.enduser_email
+                                      WHEN devicelastlogin.domain IS NOT NULL
+                                        THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                      ELSE devicelastlogin.username
+                                        END AS last_login_by,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v2.virtualsubtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    case
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND (lower(view_device_v2.virtualsubtype) = 'citrix/xen'
+                                                or lower(view_device_v2.virtualsubtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'hyper-v')
+                                            or (view_device_v2.virtual_host and lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    case
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')  then null
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' and (view_device_v2.vm_manager_int_id IS NULL OR view_device_v2.vm_manager_int_id = '' OR view_device_v2.uuid IS NULL OR view_device_v2.uuid = '')) then null
+                                      when view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      when (lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware') then concat_ws('_',view_device_v2.vm_manager_int_id, lower(view_device_v2.uuid))
+                                      else lower(ci.instance_id)
+                                    end as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v2.os_name, view_device_v2.os_version, view_device_v2.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v2.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v2.name, position('.' in view_device_v2.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+                                    view_device_v2.details ->> 'imei' AS imei,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+                                    case
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) in ('network printer', 'router', 'firewall', 'access point') THEN network_hw.hwaddress
+                                        WHEN view_device_v2.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address,
+                                    k8snode.k8s_cluster_name,
+                                    k8snode.k8s_cluster_url,
+                                    k8snode.k8s_architecture,
+                                    k8snode.k8s_os_image,
+                                    k8snode.k8s_creation_timestamp,
+                                    k8snode.k8s_resource_version,
+                                    k8snode.k8s_os_name,
+                                    coalesce(view_device_v2.details->>'used by', view_device_v2.details->>'email_address', view_device_v2.details->>'user_principal_name') AS used_by
+                                FROM view_device_v2
+                                LEFT JOIN view_hardware_v2          on view_device_v2.hardware_fk   = view_hardware_v2.hardware_pk
+                                LEFT JOIN view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v2.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v2.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v2.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v2.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v2.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v2.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v2.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v2.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v2.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v2.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON ci.vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v2.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v2.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v2.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v2 as virtual_host_device     ON view_device_v2.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v2.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v2.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v2.device_pk     = network_port_count.device_fk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 
+                     device42-id="device42_id" 
+                     name="name" 
+                     serial-number="serial_no" 
+                     uuid="uuid" 
+                     item-id="instance_id"
+                     mac-address="snmp_device_mac_address"
+                     imei-number="imei" 
+                />
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v2.last_edited>'%s' ">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255" resource-description="Organizations Custom Asset Number of a Physical Device - This can be entered manually or managed via Asset Number Profiles -Typically used to track inventory on Devices such as Laptops, Mobile Phones, etc with barcode labels -This does not link to the database Assets directly" target-description="Asset Tag"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true" resource-description="Device name in Device42" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000" resource-description="User-Defined Notes against a Device" target-description="Description"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General" resource-description="End-of-life date for the asset" resource-description-manual="true" target-description="End of Life"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true" resource-description="Is the Device In Service?" target-description="Asset State">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255" resource-description="Hardware model name" resource-description-manual="true" target-description="Product"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Product"/>
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true" resource-description="Hardware serial number" resource-description-manual="true" target-description="Serial Number"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" resource-description="Warranty duration in months (derived from purchase orders)" resource-description-manual="true" target-description="Warranty"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Warranty expiration date from the most recent contract" resource-description-manual="true" target-description="Warranty Expiry Date"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Date the asset was acquired or purchased" resource-description-manual="true" target-description="Acquisition Date"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255" resource-description="Network domain the device belongs to" resource-description-manual="true" target-description="Domain"/>
+                <field resource="last_discovered" source-type="datetime" target="last_audit_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Date and time the device was last discovered by Device42" resource-description-manual="true" target-description="Last Audit Date"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true" resource-description="Total purchase cost from associated purchase line items" resource-description-manual="true" target-description="Cost" target-description-manual="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255" resource-description="Cloud region where the instance is deployed" resource-description-manual="true" target-description="Region"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" resource-description="Type of device - Examples are: Physical, Virtual, Cluster, or Unknown" target-description="Type"/>
+                <field resource="physicalsubtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" resource-description="Name for the Physical Subtype of the Device - such as PDU, Access Point, or Laptop - Additional Values can be manually entered as needed" target-description="Physical Subtype"/>
+                <field resource="virtualsubtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" resource-description="Virtual Subtype for Device - such as Internal VM, Azure SQL Server, VMWare, Docker Container, or Amazon Service" target-description="Virtual Subtype"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="UUID"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Operating system version string" resource-description-manual="true" target-description="OS Version"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="OS service pack or build number" resource-description-manual="true" target-description="OS Service Pack"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Device hostname" resource-description-manual="true" target-description="Hostname"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Username of the last logged-in user" resource-description-manual="true" target-description="Last login by"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" resource-description="CPU clock speed in MHz" resource-description-manual="true" target-description="CPU Speed(GHz)"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer" resource-description="Total CPU cores (cores per CPU x number of CPUs)" resource-description-manual="true" target-description="CPU Core Count"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory(GB)"/>
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" resource-description="Total disk space in GB" resource-description-manual="true" target-description="Disk Space(GB)"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer" resource-description="Current Status of the Cloud Instance such as Running, Deleted, Stopped, etc" target-description="State">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" resource-description="Device name in Device42" resource-description-manual="true" target-description="Item Name"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="The Type of Cloud Instance such as e2-small, Standard_B2ms, t3 xlarge, etc" target-description="Instance Type"/>
+                <field resource="used_by" source-type="string" target="user_email" target-type="string" resource-description="Email address of the primary user (last login)" resource-description-manual="true" target-description="Used By" target-description-manual="true"/>
+                <!--  ~Computer -->
+
+                <!--  Mobile -->
+                <field resource="os_name" source-type="string" target="os" target-type="dropdown"
+                       target-header="Mobile" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255" resource-description="Operating system version string" resource-description-manual="true" target-description="OS Version"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="string"
+                       target-header="Mobile" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory(GB)"/>
+                <field resource="imei" source-type="string" target="imei_number" target-type="string"
+                       target-header="Mobile" min-length="1" max-length="255" resource-description="Mobile device IMEI number" resource-description-manual="true" target-description="IMEI Number"/>
+                <!--  ~Mobile -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true" resource-description="Total purchase cost from associated purchase line items" resource-description-manual="true" target-description="Cost"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the instance is deployed" resource-description-manual="true" target-description="Region"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="last_discovered" source-type="datetime" target="cloud_last_audit_date" target-type="datetime"
+                       target-header="Cloud" resource-description="Date and time the device was last discovered by Device42" resource-description-manual="true" target-description="Last Audit Date"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware cluster the host belongs to" resource-description-manual="true" target-description="Cluster"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware datastore mount point or name" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="Hypervisor software name and version" resource-description-manual="true" target-description="Hypervisor"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS Type"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="Instance UUID"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Hardware Vendor"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255" resource-description="VMware datastore mount point or name" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255" resource-description="Universally Unique Identifier (UUID) for the device" resource-description-manual="true" target-description="Instance UUID"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VMware cluster the VM is running on" resource-description-manual="true" target-description="Cluster"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Account ID"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Instance ID"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Identifier Key for Image File of Cloud Instance" target-description="Image Id"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" resource-description="Operating System platform for Cloud Instance (Windows, Canonical, etc)" target-description="Platform"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Subnet identifier" resource-description-manual="true" target-description="Subnet ID"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="VRF group name (maps to VPC in Freshservice)" resource-description-manual="true" target-description="VPC ID"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Subscription ID"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Device hostname" resource-description-manual="true" target-description="Computer Name"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Firewall -->
+
+                <!-- Access Point -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Access Point" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Access Point" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Access Point" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Access Point" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Access Point" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Access Point -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" resource-description="Name of the Cloud Instance" target-description="Item Name"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Switch -->
+                <!-- Kubernetes Node -->
+                <field resource="k8s_cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Node" resource-description="Kubernetes cluster name the node belongs to" resource-description-manual="true" target-description="Cluster Name"/>
+                <field resource="k8s_cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Node" resource-description="Kubernetes cluster API server URL for the node" resource-description-manual="true" target-description="Cluster Url"/>
+                <field resource="k8s_architecture" source-type="string" target="architecture" target-type="string" target-header="AWS K8s Node" resource-description="CPU architecture reported by the Kubernetes node" resource-description-manual="true" target-description="Architecture"/>
+                <field resource="k8s_os_name" source-type="string" target="operating_system" target-type="string" target-header="AWS K8s Node" resource-description="Operating system name reported by the Kubernetes node" resource-description-manual="true" target-description="Operating System"/>
+                <field resource="k8s_os_image" source-type="string" target="os_image" target-type="string" target-header="AWS K8s Node" resource-description="OS image name reported by the Kubernetes node" resource-description-manual="true" target-description="OS Image"/>
+                <field resource="k8s_creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Computer" min-length="1" max-length="255" resource-description="Date and time the Kubernetes node was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+                <field resource="k8s_resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Node" min-length="1" max-length="255" resource-description="Kubernetes resource version for the node" resource-description-manual="true" target-description="Resource Version"/>
+                <!-- ~Kubernetes Node -->                
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v2.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+                <field resource="device_subtype" source-type="string" display-name="Device Subtype"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Devices" type="asset" description="Copy Servers from Device42 to Freshservice using DOQL v1" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH
+                                devicelastlogin AS (
+                                    with sub as ( SELECT dll.device_fk, dll.username, dll.domain, ROW_NUMBER() OVER(PARTITION BY dll.device_fk ORDER BY dll.last_login DESC) AS rank FROM view_devicelastlogin_v1 dll )
+                                   SELECT sub.*,
+                                     (
+                                      SELECT enduser.email
+                                      FROM view_enduser_v1 enduser
+                                      WHERE enduser.name = sub.username
+                                      ORDER BY enduser.enduser_pk DESC
+                                      LIMIT 1
+                                     ) AS enduser_email
+                                    FROM sub
+                                    WHERE rank = 1 )
+
+                                ,alias as ( SELECT device_fk,  string_agg(alias_name, ', ' order by alias_name) as hostname FROM view_devicealias_v1 GROUP BY device_fk)
+
+                                ,assetlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, alc.date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date DESC) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Purchased')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,asset_endlifecycle AS (
+                                    with sub as  (
+                                        SELECT alc.device_fk, to_char(alc.date, 'YYYY-MM-DD') as date,
+                                            ROW_NUMBER() OVER(PARTITION BY alc.device_fk ORDER BY alc.date) AS rank
+                                        FROM view_assetlifecycle_v1 alc
+                                        INNER JOIN view_assetaction_v1 aaction ON alc.assetaction_fk = aaction.assetaction_pk WHERE aaction.name = 'Retired')
+                                    SELECT *   FROM sub  WHERE rank = 1    )
+
+                                ,warranty AS (
+                                    with sub as (
+                                                SELECT plid.device_fk, pli.start_date, pli.end_date,
+                                                    extract(year from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) warranty_years,
+                                                    extract(month from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) + case when extract(day from age(pli.end_date, CASE WHEN lower(ven.name)='meraki' and pli.start_date='1970-01-01' THEN null else pli.start_date end)) > 0 then 1 else 0 end  warranty_months,
+                                                    ven.name as purchase_order_vendor,
+                                                    ROW_NUMBER() OVER(PARTITION BY plid.device_fk ORDER BY pli.end_date DESC) AS rank
+                                                FROM view_purchaselineitems_to_devices_v1 plid
+                                                INNER JOIN view_purchaselineitem_v1 pli ON plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                                                LEFT JOIN view_purchase_v1 pur ON pli.purchase_fk = pur.purchase_pk
+                                                LEFT JOIN view_vendor_v1 ven ON pur.vendor_fk=ven.vendor_pk
+                                                WHERE lower(pli.line_type) = 'contract'
+                                                    and ( lower(pli.contract_type_name) = 'warranty'
+                                                            or ( lower(pli.contract_type_name) in ('base', 'upgrade') and lower(ven.name) in ('ibm', 'lenovo'))
+                                                        )
+                                                      and pli.end_date is not null
+                                                )
+                                       SELECT *  FROM sub  WHERE rank = 1 )
+
+                                ,part_count as (
+                                    SELECT p.device_fk,
+                                         SUM(p.pcount *
+                                             CASE
+                                               WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                               WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                               WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                               WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                                               ELSE NULL
+                                             END) AS total_part_disk_size
+                                         FROM view_part_v1 p
+                                         INNER JOIN view_partmodel_v1 pm ON p.partmodel_fk = pm.partmodel_pk
+                                         WHERE pm.type_id = 3 AND pm.hdsize IS NOT NULL AND p.pcount > 0 AND p.device_fk IS NOT NULL
+                                         GROUP BY p.device_fk )
+
+                                ,network_port_count as (
+                                    SELECT p.device_fk,
+                                         count(*) AS total_port_count
+                                         from (
+                                            select device_fk, hwaddress from view_netport_v1 where device_fk is not null
+                                            union
+                                            select second_device_fk as device_fk, hwaddress from view_netport_v1 where second_device_fk is not null
+                                            ) p
+                                         WHERE p.device_fk is not null
+                                         GROUP BY p.device_fk )
+
+                                ,total_costs as (
+                                    select device_fk, sum(cost) as cost from view_purchaselineitem_v1 left join view_purchaselineitems_to_devices_v1 on purchaselineitem_fk = purchaselineitem_pk  group by device_fk)
+
+                                ,network_hw as (
+                                    select
+                                        n.device_fk,
+                                        n.hwaddress
+                                    from view_netport_v1 n
+                                    where n.netport_pk in (
+                                        select min(n.netport_pk) as netport_pk
+                                        from view_netport_v1 n
+                                        where n.device_fk is not null and n.hwaddress is not null AND LENGTH(TRIM(n.hwaddress)) = 12
+                                        group by n.device_fk
+                                    )
+                                )
+
+                                ,network_ip as (
+                                    select
+                                        vip.device_fk,
+                                        string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then
+                                            host(vip.ip_address)::character varying
+                                            else null end, ', ' order by vip.ip_address) as private_ip_address,
+                                        string_agg(case when vip.ip_address &lt;&lt; inet '10/8' or vip.ip_address &lt;&lt; inet '192/8' or vip.ip_address &lt;&lt; inet '172.16/12' then null
+                                            else host(vip.ip_address)::character varying end, ', ' order by vip.ip_address) as public_ip_address,
+                                        string_agg(host(vip.subnet_mask)::character varying, ', ' order by vip.ip_address) as subnet_mask
+                                        from (select distinct device_fk, ip_address, netmask(set_masklen(view_subnet_v1.network, view_subnet_v1.mask_bits)) as subnet_mask
+                                            from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk)
+
+                                ,subnet as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(host(vn.network)::character varying, ', ' order by vn.network) as network
+                                        from (select distinct device_fk, network from view_ipaddress_v1 left join view_subnet_v1 on subnet_pk=subnet_fk) vn group by vn.device_fk)
+
+                                ,vrfgroup as (
+                                    select
+                                        vn.device_fk,
+                                        string_agg(vn.vrfgroup, ', ' order by vn.vrfgroup) as vrfgroup
+                                        from (select distinct device_fk, view_vrfgroup_v1.name as vrfgroup from view_ipaddress_v1
+                                        left join view_subnet_v1 on subnet_pk=subnet_fk
+                                        left join view_vrfgroup_v1 on vrfgroup_pk=vrfgroup_fk) vn group by vn.device_fk)
+
+                                ,device_cluster AS (
+                                    SELECT device_cluster.child_device_fk device_fk,
+                                        string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                                        FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+
+                                ,mount_point as (
+                                    select mp.device_fk,  string_agg(mp.mountpoint, ', ' order by mp.mountpoint) as mountpoint from view_mountpoint_v1 mp group by mp.device_fk)
+
+                                select
+                                    view_device_v1.device_pk,
+                                    CASE
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') OR
+                                             (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine' OR lower(view_device_v1.virtual_subtype) = 'azure cloud service'))
+                                            THEN
+                                                CASE
+                                                    WHEN position('/' IN view_device_v1.name) > 0 THEN
+                                                        substring(view_device_v1.name FROM position('/' IN view_device_v1.name) + 1)
+                                                    ELSE
+                                                        CASE
+                                                            WHEN ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                            ELSE ci.instance_name
+                                                        END
+                                                END
+                                        ELSE
+                                            case
+                                                when ci.instance_name is null or ci.instance_name = '' then view_device_v1.name
+                                                else ci.instance_name
+                                            end
+                                    END as name,
+                                    view_device_v1.serial_no,
+                                    view_device_v1.uuid,
+                                    view_device_v1.asset_no,
+                                    view_device_v1.in_service,
+                                    view_device_v1.os_name,
+                                    view_device_v1.os_version,
+                                    view_device_v1.datacenter,
+                                    view_device_v1.notes,
+                                    view_device_v1.type as device_type,
+                                    view_device_v1.sub_type as physical_subtype,
+                                    view_device_v1.virtual_subtype,
+                                    view_device_v1.network_device,
+                                    view_device_v1.blade_chassis,
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'VMware VCenter Host'
+                                        WHEN view_device_v1.virtual_host THEN 'Host'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Laptop'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Windows Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Unix Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'AIX Server'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Solaris Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'VMware VCenter VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'AWS VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Azure VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'GCP VM'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Server'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Server'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+                                    view_device_v1.cpucount * view_device_v1.cpucore as total_cpucore,
+                                    t_cost.cost,
+                                    case WHEN view_device_v1.type = 'Virtual' THEN view_device_v1.type WHEN view_device_v1.type = 'Cluster' THEN view_device_v1.type ELSE coalesce(view_hardware_v1.name, view_device_v1.type) END as hw_model,
+                                    view_vendor_v1.name as manufacturer,
+                                    case WHEN view_device_v1.hz = 'MHz' and view_device_v1.cpupower is not null  THEN view_device_v1.cpupower / 1000 ELSE view_device_v1.cpupower END as cpuspeed,
+                                    case WHEN view_device_v1.ram_size_type = 'MB' and view_device_v1.ram is not null  THEN view_device_v1.ram / 1024 WHEN view_device_v1.ram_size_type = 'TB' and view_device_v1.ram is not null  THEN view_device_v1.ram * 1024 ELSE view_device_v1.ram END as ramsize,
+                                    network_ip.ip_address, network_ip.public_ip_address, network_ip.private_ip_address, network_ip.subnet_mask, network_hw.hwaddress,
+                                    CEIL(COALESCE(p.total_part_disk_size,
+                                                    CASE
+                                                        WHEN view_device_v1.hard_disk_count IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size IS NOT NULL AND
+                                                             view_device_v1.hard_disk_size_type IS NOT NULL THEN
+                                                                CASE
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'GB' THEN view_device_v1.hard_disk_size
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'TB' THEN view_device_v1.hard_disk_size * 1024
+                                                                    WHEN view_device_v1.hard_disk_size_type = 'PB' THEN view_device_v1.hard_disk_size * 1024 * 1024
+                                                                    ELSE NULL
+                                                                END
+                                                        ELSE NULL
+                                                    END)) AS disk_size,
+                                    warranty.warranty_months + (warranty.warranty_years * 12) as warranty_months,
+                                    warranty.end_date as warranty_end_date,
+                                    warranty.purchase_order_vendor as purchase_order_vendor,
+                                    assetlifecycle.date as acquisition_date,
+                                    asset_endlifecycle.date as end_of_life,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version_no else view_device_v1.os_version end as device_os_version,
+                                    case when lower(view_device_v1.os_name) like '%windows%' or lower(view_device_v1.os_name) like '%microsoft%' then view_device_v1.os_version else view_device_v1.os_version_no end as device_os_version_no,
+                                    COALESCE(alias.hostname, view_device_v1.name) AS hostname,
+                                    CASE
+                                      WHEN devicelastlogin.enduser_email IS NOT NULL AND devicelastlogin.enduser_email &lt;&gt; ''
+                                        THEN devicelastlogin.enduser_email
+                                      WHEN devicelastlogin.domain IS NOT NULL
+                                        THEN devicelastlogin.username || '@' || devicelastlogin.domain
+                                      ELSE devicelastlogin.username
+                                        END AS last_login_by,
+                                    case
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance')
+                                            or lower(civ.name) similar to '%(aws|amazon)%' THEN 'AWS'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine')
+                                            or lower(civ.name) similar to '%(azure|microsoft)%' THEN 'AZURE'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware')
+                                            or lower(civ.name) like '%vmware%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%esxi%') then 'VMWARE VCENTER'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce')
+                                            or lower(civ.name) similar to '%(google|gce|gcp)%' then 'GCP'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'oracle cloud instance')
+                                            or lower(civ.name) like '%oracle%' then 'Oracle Cloud'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'citrix/xen'
+                                                or lower(view_device_v1.virtual_subtype) = 'xen'))
+                                            or lower(civ.name) similar to '%(citrix|xen)%'
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) like '%xenserver%') then 'Citrix'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'hyper-v')
+                                            or (view_device_v1.virtual_host and lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%') then 'Hyper-V'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'digitalocean instance')
+                                            or lower(civ.name) similar to '%(digitalocean|digital ocean)%' then 'Digital Ocean'
+                                        WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'alibaba cloud instance')
+                                            or lower(civ.name) like '%alibaba%' then 'Alibaba Cloud'
+                                        else null
+                                    end as cloud_vendor,
+                                    lower(ci.instance_id) as instance_id,
+                                    ci.instance_name as cloud_instance_name,
+                                    ci.status as cloud_instance_status,
+                                    ci.instance_type as cloud_instance_type,
+                                    ci.account as cloud_account,
+                                    ci.image_id as cloud_image_id,
+                                    ci.os_platform as cloud_os_platform,
+                                    subnet.network as subnet,
+                                    vrfgroup.vrfgroup as vrfgroup,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 1)
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN substr(ci.location, 1, length(ci.location) - 2)
+                                      ELSE NULL
+                                    END AS cloud_instance_region,
+                                    CASE
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance') THEN ci.location
+                                      WHEN (lower(view_device_v1.type) = 'virtual' AND (lower(view_device_v1.virtual_subtype) = 'azure virtual machine'
+                                                                                                         OR lower(view_device_v1.virtual_subtype) = 'azure cloud service')) THEN NULL
+                                      WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' AND LENGTH(ci.location) > 0 THEN ci.location
+                                      ELSE NULL
+                                    END AS cloud_instance_location,
+                                    device_cluster.device_cluster_name as device_cluster_name,
+                                    mount_point.mountpoint as mountpoint,
+                                    CONCAT_WS(' ',  view_device_v1.os_name, view_device_v1.os_version, view_device_v1.os_version_no) as hypervisor,
+                                    hv.name as hardware_vendor,
+                                    virtual_host_device.datacenter as host_datacenter,
+                                    host_device_cluster.device_cluster_name as host_cluster_name,
+                                	case
+                                       when devicelastlogin.domain is not null then devicelastlogin.domain
+                                       when view_device_v1.name ~* '^((?!-)[A-Za-z0-9-]{{1,63}}(?&lt;!-)\.)+[A-Za-z]{{2,6}}$' then substring(view_device_v1.name, position('.' in view_device_v1.name)+1)
+	                                else null end domain_name,
+	                                network_port_count.total_port_count as total_port_count,
+	                                format('Device-%s', view_device_v1.device_pk) as device42_id,
+                                    case
+                                        WHEN view_device_v1.network_device THEN network_hw.hwaddress
+                                        ELSE NULL
+                                    end as snmp_device_mac_address
+                                FROM view_device_v1
+                                LEFT JOIN view_hardware_v1          on view_device_v1.hardware_fk   = view_hardware_v1.hardware_pk
+                                left join view_vendor_v1            on view_vendor_v1.vendor_pk     = view_hardware_v1.vendor_fk
+                                LEFT JOIN network_ip                on view_device_v1.device_pk     = network_ip.device_fk
+                                LEFT JOIN network_hw                on view_device_v1.device_pk     = network_hw.device_fk
+                                LEFT JOIN total_costs t_cost        on t_cost.device_fk             = device_pk
+                                LEFT OUTER JOIN part_count AS p     ON view_device_v1.device_pk     = p.device_fk
+                                LEFT OUTER JOIN warranty            ON view_device_v1.device_pk     = warranty.device_fk
+                                LEFT OUTER JOIN assetlifecycle      ON view_device_v1.device_pk     = assetlifecycle.device_fk
+                                LEFT OUTER JOIN asset_endlifecycle  ON view_device_v1.device_pk     = asset_endlifecycle.device_fk
+                                LEFT OUTER JOIN alias               ON view_device_v1.device_pk     = alias.device_fk
+                                LEFT OUTER JOIN devicelastlogin     ON view_device_v1.device_pk     = devicelastlogin.device_fk
+                                LEFT JOIN view_cloudinstance_v1 as ci     ON view_device_v1.device_pk     = ci.device_fk
+                                LEFT JOIN view_vendor_v1 as civ     ON view_device_v1.cloud_vendor_fk     = civ.vendor_pk
+                                LEFT JOIN device_cluster            ON view_device_v1.device_pk     = device_cluster.device_fk
+                                LEFT JOIN mount_point               ON view_device_v1.device_pk     = mount_point.device_fk
+                                LEFT JOIN view_vendor_v1 as hv     ON view_hardware_v1.vendor_fk     = hv.vendor_pk
+                                LEFT JOIN view_device_v1 as virtual_host_device     ON view_device_v1.virtual_host_device_fk     = virtual_host_device.device_pk
+                                LEFT JOIN device_cluster as host_device_cluster     ON virtual_host_device.device_pk     = host_device_cluster.device_fk
+                                LEFT JOIN subnet            ON view_device_v1.device_pk     = subnet.device_fk
+                                LEFT JOIN vrfgroup            ON view_device_v1.device_pk     = vrfgroup.device_fk
+                                LEFT JOIN network_port_count        ON view_device_v1.device_pk     = network_port_count.device_fk
+                                "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name" serial-number="serial_no" uuid="uuid" item-id="instance_id" mac-address="snmp_device_mac_address"/>
+            </matching>
+            <mapping key="name" source="Devices" doql-suffix=" where view_device_v1.last_edited>'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+                <!-- ~D42 Specific -->
+
+                <!--  General -->
+                <field resource="asset_no" source-type="string" target="asset_tag" target-type="string"
+                       target-header="General" min-length="1" max-length="255" resource-description="Organizations Custom Asset Number of a Physical Device - This can be entered manually or managed via Asset Number Profiles -Typically used to track inventory on Devices such as Laptops, Mobile Phones, etc with barcode labels -This does not link to the database Assets directly" target-description="Asset Tag"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true" resource-description="Device name in Device42" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="notes" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000" resource-description="User-Defined Notes against a Device" target-description="Description"/>
+                <field resource="end_of_life" source-type="datetime" target="end_of_life" target-type="date"
+                       target-header="General" resource-description="End-of-life date for the asset" resource-description-manual="true" target-description="End of Life"/>
+                <!--  ~General -->
+
+                <!--  Hardware -->
+                <field resource="in_service" source-type="boolean" target="asset_state" target-type="string"
+                       target-header="Hardware" skip-update="true" resource-description="Is the Device In Service?" target-description="Asset State">
+                    <value-mapping default="Retired">
+                        <item key="true" value="In Use"/>
+                    </value-mapping>
+                </field>
+                <field resource="hw_model" source-type="string" target="product" target-field="name" target-type="dict" max-length="255" resource-description="Hardware model name" resource-description-manual="true" target-description="Product"/>
+                <field resource="manufacturer" source-type="string" target="product" target-field="manufacturer" target-type="dict" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Product"/>
+                <!-- Temporally don't map the vendor, because there is no way to sync the products and vendors using api right now.
+                <field resource="purchase_order_vendor" source-type="string" target="vendor" target-type="string"
+                       target-header="Hardware"
+                       target-foreign="vendors" target-foreign-key="name" required="true" max-length="255"/>
+                       -->
+                <field resource="serial_no" source-type="string" target="serial_number" target-type="string"
+                       target-header="Hardware"
+                       min-length="1" max-length="255" error-skip="true" resource-description="Hardware serial number" resource-description-manual="true" target-description="Serial Number"/>
+                <field resource="warranty_months" source-type="integer" target="warranty" target-type="integer"
+                       target-header="Hardware" resource-description="Warranty duration in months (derived from purchase orders)" resource-description-manual="true" target-description="Warranty"/>
+                <field resource="warranty_end_date" source-type="datetime" target="warranty_expiry_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Warranty expiration date from the most recent contract" resource-description-manual="true" target-description="Warranty Expiry Date"/>
+                <field resource="acquisition_date" source-type="datetime" target="acquisition_date" target-type="datetime"
+                       target-header="Hardware" resource-description="Date the asset was acquired or purchased" resource-description-manual="true" target-description="Acquisition Date"/>
+                <field resource="domain_name" source-type="string" target="domain" target-type="string"
+                       target-header="Hardware" required="true" max-length="255" resource-description="Network domain the device belongs to" resource-description-manual="true" target-description="Domain"/>
+                <field resource="cost" type="float" target="cost"
+                       target-header="Hardware" target-type="float" set-zero="true" resource-description="Total purchase cost from associated purchase line items" resource-description-manual="true" target-description="Cost" target-description-manual="true"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255" resource-description="Cloud region where the instance is deployed" resource-description-manual="true" target-description="Region"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Hardware" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+                <field resource="device_type" source-type="string" target="compute_type" target-type="dropdown"
+                       target-header="Hardware" resource-description="Type of device - Examples are: Physical, Virtual, Cluster, or Unknown" target-description="Type"/>
+                <field resource="physical_subtype" source-type="string" target="physical_subtype" target-type="dropdown"
+                       target-header="Hardware" resource-description="Name for the Physical Subtype of the Device - such as PDU, Access Point, or Laptop - Additional Values can be manually entered as needed" resource-description-manual="true" target-description="Physical Subtype"/>
+                <field resource="virtual_subtype" source-type="string" target="virtual_subtype" target-type="dropdown"
+                       target-header="Hardware" resource-description="Virtual Subtype for Device - such as Internal VM, Azure SQL Server, VMWare, Docker Container, or Amazon Service" resource-description-manual="true" target-description="Virtual Subtype"/>
+                <!--  ~Hardware -->
+
+                <!--  Computer -->
+                <field resource="uuid" type="string" target="uuid"
+                       target-header="Computer"
+                       min-length="1" max-length="255" resource-description="A UUID is a Universally Unique Identifier for a Device - This is typically a discovered property of a Device and is used by the matching algorithm to help reduce duplication in the database" target-description="UUID"/>
+                <field resource="ip_address" type="string" target="computer_ip_address"
+                       target-header="Computer" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Computer" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="os_name" source-type="string" target="os" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS"/>
+                <field resource="device_os_version" source-type="string" target="os_version" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Operating system version string" resource-description-manual="true" target-description="OS Version"/>
+                <field resource="device_os_version_no" source-type="string" target="os_service_pack" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="OS service pack or build number" resource-description-manual="true" target-description="OS Service Pack"/>
+                <field resource="hostname" source-type="string" target="hostname" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Device hostname" resource-description-manual="true" target-description="Hostname"/>
+                <field resource="last_login_by" source-type="string" target="last_login_by" target-type="string"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="Username of the last logged-in user" resource-description-manual="true" target-description="Last login by"/>
+                <field resource="cpuspeed" source-type="float" target="cpu_speed" target-type="float"
+                       target-header="Computer" resource-description="CPU clock speed in MHz" resource-description-manual="true" target-description="CPU Speed(GHz)"/>
+                <field resource="total_cpucore" source-type="integer" target="cpu_core_count" target-type="integer"
+                      
+                       target-header="Computer" resource-description="Total CPU cores (cores per CPU x number of CPUs)" resource-description-manual="true" target-description="CPU Core Count"/>
+                <field resource="ramsize" source-type="float" target="memory" target-type="float"
+                       target-header="Computer" resource-description="Total RAM size in MB" resource-description-manual="true" target-description="Memory(GB)"/>
+                <field resource="disk_size" source-type="integer" target="disk_space" target-type="integer"
+                       target-header="Computer" resource-description="Total disk space in GB" resource-description-manual="true" target-description="Disk Space(GB)"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Computer" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="cloud_instance_status" source-type="string" target="state" target-type="string"
+                       target-header="Computer" resource-description="Current Status of the Cloud Instance such as Running, Deleted, Stopped, etc" target-description="State">
+                    <value-mapping default="Unknown">
+                        <item key="Running" value="Powered On"/>
+                        <item key="Stopped" value="Powered Off"/>
+                    </value-mapping>
+                </field>
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Computer" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string"
+                       target-header="Computer" resource-description="Device name in Device42" resource-description-manual="true" target-description="Item Name"/>
+                <field resource="cloud_instance_type" source-type="string" target="cd_instance_type" target-type="dropdown"
+                       target-header="Computer" min-length="1" max-length="255" resource-description="The Type of Cloud Instance such as e2-small, Standard_B2ms, t3 xlarge, etc" target-description="Instance Type"/>
+                <!--  ~Computer -->
+
+                <!--  Cloud -->
+                <field resource="cost" type="float" target="cloud_cost"
+                       target-header="Cloud" target-type="float" set-zero="true" resource-description="Total purchase cost from associated purchase line items" resource-description-manual="true" target-description="Cost"/>
+                <field resource="cloud_instance_region" source-type="string" target="region" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the instance is deployed" resource-description-manual="true" target-description="Region"/>
+                <field resource="cloud_instance_location" source-type="string" target="cd_availability_zone" target-type="dropdown"
+                       target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+                <field resource="cloud_vendor" source-type="string" target="provider_type" target-type="dropdown"
+                       target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <!--  ~Cloud -->
+
+                <!--  VMware VCenter Host -->
+                <field resource="datacenter" type="string" target="datacenter"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="device_cluster_name" type="string" target="cluster"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware cluster the host belongs to" resource-description-manual="true" target-description="Cluster"/>
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="VMware datastore mount point or name" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="hypervisor" type="string" target="hypervisor"
+                       target-header="VMware VCenter Host" max-length="255" resource-description="Hypervisor software name and version" resource-description-manual="true" target-description="Hypervisor"/>
+                <field resource="os_name" source-type="string" target="os_type" target-type="string"
+                       target-header="VMware VCenter Host" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="OS Type"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" resource-description="A UUID is a Universally Unique Identifier for a Device - This is typically a discovered property of a Device and is used by the matching algorithm to help reduce duplication in the database" target-description="Instance UUID"/>
+                <field resource="hardware_vendor" source-type="string" target="hardware_vendor" target-type="string"
+                       target-header="VMware VCenter Host"
+                       min-length="1" max-length="255" error-skip="true" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Hardware Vendor"/>
+                <!--  ~VMware VCenter Host -->
+
+                <!-- VMWare VCenter VM -->
+                <field resource="mountpoint" type="string" target="datastore"
+                       target-header="VMware VCenter VM" max-length="255" resource-description="VMware datastore mount point or name" resource-description-manual="true" target-description="Datastore"/>
+                <field resource="uuid" type="string" target="instance_uuid"
+                       target-header="VMware VCenter VM"
+                       min-length="1" max-length="255" resource-description="A UUID is a Universally Unique Identifier for a Device - This is typically a discovered property of a Device and is used by the matching algorithm to help reduce duplication in the database" target-description="Instance UUID"/>
+                <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+                <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string"
+                       target-header="VMware VCenter VM" min-length="1" max-length="255" resource-description="VMware cluster the VM is running on" resource-description-manual="true" target-description="Cluster"/>
+                <!-- ~VMWare VCenter VM -->
+
+                <!-- AWS VM -->
+                <field resource="cloud_account" source-type="string" target="account_id" target-type="integer"
+                       target-header="AWS VM" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Account ID"/>
+                <field resource="instance_id" source-type="string" target="cd_instance_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Instance ID"/>
+                <field resource="cloud_image_id" source-type="string" target="image_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Identifier Key for Image File of Cloud Instance" target-description="Image Id"/>
+                <field resource="cloud_os_platform" source-type="string" target="platform" target-type="dropdown"
+                       target-header="AWS VM" resource-description="Operating System platform for Cloud Instance (Windows, Canonical, etc)" target-description="Platform"/>
+                <field resource="subnet" source-type="string" target="subnet_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="Subnet identifier" resource-description-manual="true" target-description="Subnet ID"/>
+                <field resource="vrfgroup" source-type="string" target="vpc_id" target-type="string"
+                       target-header="AWS VM" min-length="1" max-length="255" resource-description="VRF group name (maps to VPC in Freshservice)" resource-description-manual="true" target-description="VPC ID"/>
+                <!-- ~AWS VM -->
+
+                <!-- Azure VM -->
+                <field resource="cloud_account" source-type="string" target="subscription_id" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Cloud Account or Sub ID for Cloud Instance" target-description="Subscription ID"/>
+                <field resource="hostname" source-type="string" target="computer_name" target-type="string"
+                       target-header="Azure VM" min-length="1" max-length="255" resource-description="Device hostname" resource-description-manual="true" target-description="Computer Name"/>
+                <!-- ~Azure VM -->
+
+                <!-- Printer -->
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Printer" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Printer" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Printer" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Printer -->
+
+                <!-- Router -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Router" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Router" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Router" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Router" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Router" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Router" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Router -->
+
+                <!-- Firewall -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Firewall" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Firewall" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Firewall" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Firewall" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Firewall" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Firewall -->
+
+                <!--  Load Balancer -->
+                <field resource="instance_id" source-type="string" target="item_id" target-type="string"
+                       target-header="Load Balancer" error-skip="true" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="cloud_instance_name" source-type="string" target="item_name" target-type="string"
+                       target-header="Load Balancer" resource-description="Name of the Cloud Instance" target-description="Item Name"/>
+                <!--  ~Load Balancer -->
+
+                <!-- Switch -->
+                <field resource="os_name" source-type="string" target="firmware" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255" resource-description="Operating system name (e.g. Windows Server 2019, Ubuntu 22.04)" resource-description-manual="true" target-description="Firmware"/>
+                <field resource="os_version" source-type="string" target="firmware_version" target-type="string"
+                       target-header="Switch" min-length="1" max-length="255" resource-description="The OS Version is typically the version of a named Operating System - Example in &quot;CentOS 7 3 10 0&quot;, the os_version would be 7" target-description="Firmware Version"/>
+                <field resource="ip_address" type="string" target="ip_address"
+                       target-header="Switch" max-length="255" resource-description="Primary IP address of the device" resource-description-manual="true" target-description="IP Address"/>
+                <field resource="total_port_count" source-type="integer" target="ports" target-type="integer"
+                       target-header="Switch" resource-description="Total network port count on the device" resource-description-manual="true" target-description="Ports"/>
+                <field resource="hwaddress" type="string" target="mac_address"
+                       target-header="Switch" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="subnet_mask" type="string" target="subnet_mask"
+                       target-header="Switch" max-length="255" resource-description="Network subnet mask" resource-description-manual="true" target-description="Subnet Mask"/>
+                <!-- ~Switch -->
+            </mapping>
+            <unmapping key="name" source="Devices" doql-suffix=" where view_device_v1.name='%s'">
+                <field resource="network_device" source-type="boolean" display-name="Network Device"/>
+                <field resource="blade_chassis" source-type="boolean" display-name="Blade Chassis"/>
+            </unmapping>
+            <d42url resource="device_pk" source-type="integer" url="{0}/admin/rackraj/device/{1}/" />
+        </task>
+
+        <task enable="true" name="Software" type="software" description="Copy Softwares from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="select * from (select trim(name) as name, 'discovered' as software_type, min(view_software_v1.notes) as notes, 'desktop' as application_type, min(last_changed) as last_changed from view_software_v1 group by trim(name)) a"
+                        />
+            </api>
+            <mapping key="name" source="Softwares" doql-suffix=" where last_changed>'%s'">
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" max-length="255" escape="true" resource-description="Software title name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="notes" source-type="string" target="notes" target-type="string" target-header="General" max-length="2000" resource-description="Notes associated with the software entry" resource-description-manual="true" target-description="Notes" target-description-manual="true"/>
+                <field resource="software_type" source-type="string" target="status" target-type="string" target-header="General" resource-description="Software type classification (Managed, Unmanaged, Prohibited, Ignored)" resource-description-manual="true" target-description="Status" target-description-manual="true"/>
+                <field resource="application_type" source-type="string" target="application_type" target-header="General" resource-description="Application type (desktop, SaaS, mobile, etc.)" resource-description-manual="true" target-description="Application Type" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software In Use" type="software_installation" description="Create Software Install from Software In Use" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.name as device_name, device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.install_date, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping doql-suffix=" and GREATEST(view_softwareinuse_v1.last_updated, device.last_edited, view_software_v1.last_changed)>'%s' order by view_software_v1.name" key="dependent_device_name" device-name="device_name" software-name="software_name" install-date="install_date" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Application Group Device To Device Relationships" type="asset_relationship" description="Create Relationship from Application Groups" d42_max_version="19.04.99">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select distinct
+                                   format('Device-%s', df1.dependent_device_fk) as dependent_device_device42_id,
+                                   d1.name as dependent_device_name,
+                                   format('Device-%s', df1.dependency_device_fk) as dependency_device_device42_id,
+                                   d2.name as dependency_device_name
+                                from view_deviceaffinity_v2 df1
+                                inner join view_device_v1 d1 on df1.dependent_device_fk = d1.device_pk
+                                inner join view_device_v1 d2 on df1.dependency_device_fk = d2.device_pk
+                                where df1.dependent_device_fk is not null
+                                   and df1.dependent_device_fk &lt;&gt; df1.dependency_device_fk
+                                   and df1.effective_to is null
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Application Group Device To Device Relationships" type="asset_relationship" description="Create Relationship from Application Groups" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                WITH RECURSIVE
+                                allrels AS (
+                                    SELECT
+                                        rel.applicationgrouprelationship_pk AS rel_id,
+                                        rel.is_dependency,
+                                        from_ci.applicationgroupconfigitem_pk AS from_ci_id,
+                                        from_ci.configitem_type AS from_ci_type,
+                                        from_ci.device_fk AS from_device_fk,
+                                        fp.applicationgroupconfigitem_pk AS from_parent_ci_id,
+                                        fp.configitem_type AS from_parent_ci_type,
+                                        fp.device_fk AS from_parent_device_fk,
+                                        to_ci.applicationgroupconfigitem_pk AS to_ci_id,
+                                        to_ci.configitem_type AS to_ci_type,
+                                        to_ci.device_fk AS to_device_fk,
+                                        tp.applicationgroupconfigitem_pk AS to_parent_ci_id,
+                                        tp.configitem_type AS to_parent_ci_type,
+                                        tp.device_fk AS to_parent_device_fk
+                                    FROM view_applicationgrouprelationship_v2 rel
+                                    JOIN view_applicationgroup_v2 ag
+                                        ON ag.applicationgroup_pk = rel.applicationgroup_fk AND ag.status_id = 1
+                                    JOIN view_applicationgroupconfigitem_v2 from_ci
+                                        ON from_ci.applicationgroupconfigitem_pk = rel.from_applicationgroupconfigitem_fk
+                                    LEFT JOIN view_applicationgroupconfigitem_v2 fp
+                                        ON fp.applicationgroupconfigitem_pk = from_ci.parent_applicationgroupconfigitem_fk
+                                    JOIN view_applicationgroupconfigitem_v2 to_ci
+                                        ON to_ci.applicationgroupconfigitem_pk = rel.to_applicationgroupconfigitem_fk
+                                    LEFT JOIN view_applicationgroupconfigitem_v2 tp
+                                        ON tp.applicationgroupconfigitem_pk = to_ci.parent_applicationgroupconfigitem_fk
+                                    WHERE rel.effective_to IS NULL
+                                ),
+                                global_nonapp_device_rels AS (
+                                    SELECT DISTINCT ON (
+                                        COALESCE(from_parent_ci_id, from_ci_id),
+                                        COALESCE(to_parent_ci_id, to_ci_id),
+                                        is_dependency
+                                    )
+                                        COALESCE(from_parent_ci_id, from_ci_id) AS from_ci_id,
+                                        COALESCE(from_parent_device_fk, from_device_fk) AS from_device_fk,
+                                        COALESCE(to_parent_ci_id, to_ci_id) AS to_ci_id,
+                                        COALESCE(to_parent_device_fk, to_device_fk) AS to_device_fk,
+                                        is_dependency
+                                    FROM allrels
+                                    WHERE (is_dependency = true OR to_ci_type &lt;&gt; 'appcomp')
+                                      AND COALESCE(from_parent_ci_type, from_ci_type) = 'device'
+                                      AND COALESCE(to_parent_ci_type, to_ci_type) = 'device'
+                                      AND COALESCE(from_parent_ci_id, from_ci_id)
+                                       &lt;&gt; COALESCE(to_parent_ci_id, to_ci_id)
+                                ),
+                                all_appcomp_rels AS (
+                                    SELECT * FROM allrels
+                                    WHERE is_dependency = false AND to_ci_type = 'appcomp'
+                                ),
+                                appcomp_chain AS (
+                                    SELECT
+                                        aar.rel_id,
+                                        ARRAY[aar.rel_id] AS path_ids,
+                                        aar.is_dependency,
+                                        aar.from_ci_id, aar.from_ci_type, aar.from_device_fk,
+                                        aar.from_parent_ci_id, aar.from_parent_ci_type, aar.from_parent_device_fk,
+                                        aar.to_ci_id, aar.to_ci_type, aar.to_device_fk,
+                                        aar.to_parent_ci_id, aar.to_parent_ci_type, aar.to_parent_device_fk,
+                                        (aar.from_ci_type = 'appcomp' AND aar.to_ci_type = 'appcomp') AS app_to_app,
+                                        (aar.to_parent_ci_id IS NOT NULL) AS stop_chain
+                                    FROM all_appcomp_rels aar
+                                    UNION ALL
+                                    SELECT
+                                        ac.rel_id,
+                                        ac.path_ids || dep.rel_id,
+                                        CASE WHEN ac.from_ci_type &lt;&gt; 'appcomp' AND dep.from_ci_type &lt;&gt; 'appcomp'
+                                             THEN true ELSE ac.is_dependency END,
+                                        ac.from_ci_id, ac.from_ci_type, ac.from_device_fk,
+                                        ac.from_parent_ci_id, ac.from_parent_ci_type, ac.from_parent_device_fk,
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_ci_id ELSE dep.to_ci_id END,
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_ci_type ELSE dep.to_ci_type END,
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_device_fk ELSE dep.to_device_fk END,
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_parent_ci_id ELSE dep.to_parent_ci_id END,
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_parent_ci_type ELSE dep.to_parent_ci_type END,
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_parent_device_fk ELSE dep.to_parent_device_fk END,
+                                        ac.app_to_app OR (dep.from_ci_type = 'appcomp' AND dep.to_ci_type = 'appcomp'),
+                                        CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN true
+                                             WHEN dep.to_parent_ci_id IS NOT NULL THEN true
+                                             ELSE false END
+                                    FROM all_appcomp_rels dep, appcomp_chain ac
+                                    WHERE NOT ac.stop_chain
+                                      AND NOT dep.rel_id = ANY(ac.path_ids)
+                                      AND (
+                                          (dep.from_ci_type = 'appcomp' AND dep.to_ci_type = 'appcomp' AND dep.from_ci_id = ac.to_ci_id)
+                                          OR (ac.app_to_app AND dep.to_ci_id = ac.to_ci_id AND dep.from_ci_type &lt;&gt; 'appcomp')
+                                      )
+                                ),
+                                appcomp_chain_device_rels AS (
+                                    SELECT DISTINCT ON (
+                                        COALESCE(from_parent_ci_id, from_ci_id),
+                                        COALESCE(to_parent_ci_id, to_ci_id)
+                                    )
+                                        COALESCE(from_parent_ci_id, from_ci_id) AS from_ci_id,
+                                        COALESCE(from_parent_device_fk, from_device_fk) AS from_device_fk,
+                                        COALESCE(to_parent_ci_id, to_ci_id) AS to_ci_id,
+                                        COALESCE(to_parent_device_fk, to_device_fk) AS to_device_fk,
+                                        is_dependency
+                                    FROM appcomp_chain
+                                    WHERE from_ci_id &lt;&gt; to_ci_id
+                                      AND COALESCE(from_parent_ci_type, from_ci_type) = 'device'
+                                      AND COALESCE(to_parent_ci_type, to_ci_type) = 'device'
+                                      AND COALESCE(from_parent_ci_id, from_ci_id)
+                                       &lt;&gt; COALESCE(to_parent_ci_id, to_ci_id)
+                                ),
+                                appcomp_internal_device_rels AS (
+                                    SELECT DISTINCT ON (
+                                        COALESCE(dep.from_parent_ci_id, dep.from_ci_id),
+                                        COALESCE(aar.from_parent_ci_id, aar.from_ci_id)
+                                    )
+                                        COALESCE(dep.from_parent_ci_id, dep.from_ci_id) AS from_ci_id,
+                                        COALESCE(dep.from_parent_device_fk, dep.from_device_fk) AS from_device_fk,
+                                        COALESCE(aar.from_parent_ci_id, aar.from_ci_id) AS to_ci_id,
+                                        COALESCE(aar.from_parent_device_fk, aar.from_device_fk) AS to_device_fk,
+                                        false AS is_dependency
+                                    FROM all_appcomp_rels aar
+                                    JOIN all_appcomp_rels dep ON aar.to_ci_id = dep.to_ci_id
+                                    WHERE aar.from_ci_type &lt;&gt; 'appcomp' AND dep.from_ci_type &lt;&gt; 'appcomp'
+                                      AND aar.rel_id &lt; dep.rel_id
+                                      AND COALESCE(dep.from_parent_ci_type, dep.from_ci_type) = 'device'
+                                      AND COALESCE(aar.from_parent_ci_type, aar.from_ci_type) = 'device'
+                                      AND COALESCE(dep.from_parent_ci_id, dep.from_ci_id)
+                                       &lt;&gt; COALESCE(aar.from_parent_ci_id, aar.from_ci_id)
+                                )
+                                SELECT DISTINCT
+                                    d1.name AS dependent_device_name,
+                                    format('Device-%s', d1.device_pk) AS dependent_device_device42_id,
+                                    d2.name AS dependency_device_name,
+                                    format('Device-%s', d2.device_pk) AS dependency_device_device42_id
+                                FROM (
+                                    SELECT from_device_fk, to_device_fk FROM global_nonapp_device_rels
+                                    UNION
+                                    SELECT ac.from_device_fk, ac.to_device_fk
+                                    FROM appcomp_chain_device_rels ac
+                                    WHERE ac.from_ci_id &lt;&gt; ac.to_ci_id
+                                      AND NOT EXISTS (
+                                          SELECT 1 FROM global_nonapp_device_rels g
+                                          WHERE g.from_ci_id = ac.from_ci_id AND g.to_ci_id = ac.to_ci_id
+                                      )
+                                      AND NOT EXISTS (
+                                          SELECT 1 FROM global_nonapp_device_rels g
+                                          WHERE ac.is_dependency = false
+                                            AND g.from_ci_id = ac.to_ci_id AND g.to_ci_id = ac.from_ci_id
+                                      )
+                                    UNION
+                                    SELECT ai.from_device_fk, ai.to_device_fk
+                                    FROM appcomp_internal_device_rels ai
+                                    WHERE NOT EXISTS (
+                                        SELECT 1 FROM appcomp_chain_device_rels ac
+                                        WHERE ac.from_ci_id = ai.to_ci_id AND ac.to_ci_id = ai.from_ci_id
+                                    )
+                                    AND NOT EXISTS (
+                                        SELECT 1 FROM global_nonapp_device_rels g
+                                        WHERE g.from_ci_id = ai.from_ci_id AND g.to_ci_id = ai.to_ci_id
+                                    )
+                                    AND NOT EXISTS (
+                                        SELECT 1 FROM global_nonapp_device_rels g
+                                        WHERE g.from_ci_id = ai.to_ci_id AND g.to_ci_id = ai.from_ci_id
+                                    )
+                                ) combined
+                                JOIN view_device_v1 d1 ON d1.device_pk = combined.from_device_fk
+                                JOIN view_device_v1 d2 ON d2.device_pk = combined.to_device_fk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Application Device To Device Relationships" type="asset_relationship" description="Create Relationship from Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                       case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                       case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Connected to" upstream-relationship="Connected to" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_min_version="16.19.00">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name, ba.description, ba.criticality,
+                                    cus.name as customer_name, eu.email as owner_email,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                                left join view_customer_v1 cus on ba.customer_fk = cus.customer_pk
+                                left join view_enduser_v1 eu on ba.business_app_owner_enduser_fk = eu.enduser_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where GREATEST(ba.last_changed, eu.last_updated) >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this business application" resource-description-manual="true" target-description="Device42 ID"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true" resource-description="Business application name in Device42" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="description" source-type="string" target="description" target-header="General"
+                       min-length="1" max-length="60000" resource-description="Business application description" resource-description-manual="true" target-description="Description"/>
+                <field resource="criticality" source-type="string" target="impact" target-type="string"
+                       target-header="General" resource-description="Name of Criticality for the Business Service (Mission Critical, Business Essential, etc) " target-description="Impact">
+                    <value-mapping default="low">
+                        <item key="Business Core" value="low"/>
+                        <item key="Business Essential" value="medium"/>
+                        <item key="Business Supporting" value="medium"/>
+                        <item key="Mission Critical" value="high"/>
+                    </value-mapping>
+                </field>
+                <field resource="owner_email" source-type="string" target="user_id" target-type="string"
+                       target-header="Assignment"
+                       target-foreign="agents" target-foreign-key="email" target-field="user_id" resource-description="Email for End User" target-description="Used By"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Applications" type="asset" description="Copy Business Application from Device42 to Freshservice" d42_max_version="16.18.02">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.businessapplication_pk, ba.name,
+                                    'Business Service' as asset_type,
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" name="name"/>
+            </matching>
+            <mapping key="name" source="Businessapps" doql-suffix=" where ba.last_changed >'%s'">
+                <!-- D42 Specific -->
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this business application" resource-description-manual="true" target-description="Device42 ID"/>
+                <!-- ~D42 Specific -->
+
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General"
+                       min-length="1" max-length="248" escape="true" resource-description="Business application name in Device42" resource-description-manual="true" target-description="Display Name"/>
+            </mapping>
+            <unmapping key="name" doql-suffix=" where ba.name='%s'">
+            </unmapping>
+            <d42url resource="businessapplication_pk" source-type="integer" url="{0}/admin/rackraj/businessapp/{1}/" />
+        </task>
+
+        <task enable="true" name="Business Application To Device Relationships" type="asset_relationship" description="Create Relationship from Devices to Business Apps">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select ba.name as business_app_name,
+                                format('BusinessApp-%s', ba.businessapplication_pk) as business_app_device42_id,
+                                d.name as device_name,
+                                format('Device-%s', d.device_pk) as device_device42_id
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="business_app_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="business_app_name" downstream-relationship="Hosted On" upstream-relationship="Hosts" target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Contracts" type="contract" description="Copy contract info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select plid.device_name, v.name vendor_name,
+                                v.name || '-' || p.order_no || '-' || pli.line_no as name,
+                                case
+                                    WHEN lower(pli.contract_type_name) = 'warranty' THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) in ('base', 'upgrade') and lower(v.name) in ('ibm', 'lenovo') THEN 'Warranty'
+                                    WHEN lower(pli.contract_type_name) = 'lease' THEN 'Lease'
+                                    ELSE 'Maintenance'
+                                end as contract_type_name,
+                                pli.contract_id, pli.cost, pli.start_date, pli.end_date
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true" resource-description="Contract name in Device42" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true" resource-description="Contract name in Device42" resource-description-manual="true" target-description="Contract Number" target-description-manual="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Vendor" target-description-manual="true"/>
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" resource-description="Contract type name (Lease, Warranty, Maintenance, etc.)" resource-description-manual="true" target-description="Contract Type" target-description-manual="true">
+                    <value-mapping default="Maintenance">
+                        <item key="Lease" value="Lease"/>
+                        <item key="Warranty" value="Warranty"/>
+                        <item key="Maintenance" value="Maintenance"/>
+                    </value-mapping>
+                </field>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true" resource-description="Unit cost for PO Line Item" target-description="Cost"/>
+                <field resource="start_date" source-type="string" target="start_date" resource-description="Start Date for PO Line Item" target-description="Start Date" target-description-manual="true"/>
+                <field resource="end_date" source-type="string" target="end_date" resource-description="End Date for PO Line Item" target-description="End Date" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Device Contract Associations" type="contract_asset" description="Create association between asset and contract">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select v.name || '-' || p.order_no || '-' || pli.line_no as contract_name,
+                                   plid.device_name,
+                                   format('Device-%s', plid.device_fk) as device_device42_id
+                            from view_purchaselineitems_to_devices_v1 plid
+                            inner join view_purchaselineitem_v1 pli on plid.purchaselineitem_fk = pli.purchaselineitem_pk
+                            inner join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            inner join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            where lower(pli.line_type) = 'contract' and
+                                pli.start_date is not null and pli.end_date is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping device-name="device_name" contract-name="contract_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Software Licensing" type="contract" description="Copy Software Licensing info from Device42 to Freshservice">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select 	case when p.order_no is null then s.name else s.name || '-' || p.order_no || '-' || pli.line_no end as name,
+                                    'Software License' as contract_type_name,
+                                    case when v.name is not null then v.name else sv.name end vendor_name,
+                                    pli.cost unit_cost, pli.start_date, pli.end_date,
+                                    s.name software_name,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end licensed_count,
+                                    case when pli.quantity is not null then pli.quantity else s.licensed_count end * pli.cost as cost,
+                                    pli.contract_id,
+                                    case when slm.is_free = true then 'Free' else 'Volume' end license_type,
+                                    pli.frequency,
+                                    'per_unit' as pricing_model,
+                                    case when pli.notes is not null and pli.notes &lt;&gt; '' then pli.notes else s.notes end as notes
+                            from view_software_v1 s
+                            left outer join view_softwarelicensemodel_v1 slm on s.softwarelicensemodel_fk = slm.softwarelicensemodel_pk
+                            left outer join view_purchaselineitems_to_softwares_v1 plis on s.software_pk = plis.software_fk
+                            left outer join view_purchaselineitem_v1 pli on plis.purchaselineitem_fk = pli.purchaselineitem_pk
+                            left outer join view_purchase_v1 p on pli.purchase_fk = p.purchase_pk
+                            left outer join view_vendor_v1 v on p.vendor_fk = v.vendor_pk
+                            left outer join view_vendor_v1 sv on s.vendor_fk = sv.vendor_pk
+                            WHERE
+                                lower(s.software_type) = 'managed' and
+                                (pli.purchaselineitem_pk is not null or s.licensed_count is not null) and
+                                (v.name is not null or sv.name is not null)
+                            "
+                        />
+            </api>
+            <mapping key="name">
+                <field resource="name" source-type="string" target="name" target-type="string" max-length="255" escape="true" resource-description="Software title name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="name" source-type="string" target="contract_number" target-type="string" max-length="255" escape="true" resource-description="Software title name" resource-description-manual="true" target-description="Contract Number" target-description-manual="true"/>
+                <field resource="vendor_name" source-type="string" target="vendor_id" target-type="string"
+                       target-foreign="vendors" target-foreign-key="name" max-length="255" resource-description="Software vendor name" resource-description-manual="true" target-description="Vendor" target-description-manual="true"/>
+                <field resource="contract_type_name" source-type="string" target="contract_type_id" target-type="string"
+                       target-foreign="contract_types" target-foreign-key="name" resource-description="Contract type name (Lease, Warranty, Maintenance, etc.)" resource-description-manual="true" target-description="Contract Type" target-description-manual="true"/>
+                <field resource="software_name" source-type="string" target="software_id" target-type="string"
+                       target-foreign="applications" target-foreign-key="name" escape="true" resource-description="Name of Software" target-description="Software" target-description-manual="true"/>
+                <field resource="cost" source-type="float" target="cost" target-type="float" not-zero="true" resource-description="License cost per unit" resource-description-manual="true" target-description="Cost"/>
+                <field resource="start_date" source-type="string" target="start_date" resource-description="Start Date for PO Line Item" target-description="Start Date" target-description-manual="true"/>
+                <field resource="end_date" source-type="string" target="end_date" resource-description="End Date for PO Line Item" target-description="End Date" target-description-manual="true"/>
+                <field resource="frequency" source-type="string" target="billing_cycle" target-type="string" resource-description="Frequency for PO Line Item" target-description="Billing Cycle" target-description-manual="true">
+                    <value-mapping default="one_time">
+                        <item key="one time" value="one_time"/>
+                        <item key="monthly" value="monthly"/>
+                        <item key="quarterly" value="quarterly"/>
+                        <item key="bi-annually" value="six_month"/>
+                        <item key="annually" value="annual"/>
+                        <item key="2years" value="annual"/>
+                        <item key="3years" value="annual"/>
+                        <item key="4years" value="annual"/>
+                        <item key="5years" value="annual"/>
+                    </value-mapping>
+                </field>
+                <field resource="unit_cost" source-type="float"
+                       target="item_cost_details" target-type="float"
+                       target-sub-key="cost"
+                       not-zero="true" resource-description="Unit cost for PO Line Item" target-description="Unit Cost" target-description-manual="true"/>
+                <field resource="pricing_model" source-type="string"
+                       target="item_cost_details" target-sub-key="pricing_model" resource-description="License pricing model (per device, per user, etc.)" resource-description-manual="true" target-description="Pricing Model" target-description-manual="true"/>
+                <field resource="licensed_count" source-type="integer"
+                       target="item_cost_details" target-type="integer"
+                       target-sub-key="count" resource-description="Number of licenses in the contract" resource-description-manual="true" target-description="License Count" target-description-manual="true"/>
+                <field resource="notes" source-type="string" target="item_cost_details"
+                       target-sub-key="comments"
+                       min-length="1" max-length="60000" resource-description="Notes associated with the software entry" resource-description-manual="true" target-description="Cost Notes" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between Host and Virtual Machine" type="asset_relationship" description="Create relationship between Host and Virtual Machine">
+            <api>
+                <target/>
+                <resource
+                          doql="
+								WITH
+                                    host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                    ),
+                                    vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                    )
+
+                                select
+                                    hd.device_pk as dependency_device_fk,
+                                    hd.name as dependency_device_name,
+                                    format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                    vmd.device_pk as dependent_device_fk,
+                                    vmd.name as dependent_device_name,
+                                    format('Device-%s', vmd.device_pk) as dependent_device_device42_id
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk"
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="Virtualized by" upstream-relationship="Virtualizes" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="Create relationship between cluster and device" type="asset_relationship" description="Create relationship between cluster and device">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                                select dp.name as parent_device_name,
+                                format('Device-%s', dp.device_pk) as parent_device_device42_id,
+                                dc.name as child_device_name,
+                                format('Device-%s', dc.device_pk) as child_device_device42_id
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="child_device_device42_id"/>
+                <source-2 device42-id="parent_device_device42_id"/>
+            </matching>
+            <mapping key="child_device_name" downstream-relationship="Member of" upstream-relationship="Includes" target-key="parent_device_name">
+            </mapping>
+        </task>
+
+    <task enable="true" name="D42 AWS ALB to Freshservice AWS ALB" type="asset" description="Copy AWS ALB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              resource.details ->> 'dns_name'               AS dns_name,
+              resource.details ->> 'dns_name'               AS fqdn,
+              resource.details ->> 'hosted_zone_id'         AS canonical_hosted_zone_id,
+              (resource.details ->> 'created')::timestamptz AS created_time,
+              resource.details ->> 'ip_address_type'        AS ip_address_type,
+              resource.details ->> 'load_balancer_type'     AS resource_type,
+              resource.details ->> 'scheme'                 AS scheme,
+              resource.details ->> 'status'                 AS state,
+              resource.details ->> 'vpc_id'                 AS vpc_id,
+              (SELECT STRING_AGG(host(ip.ip_address)::text, ', ') FROM view_ipaddress_v2 ip WHERE ip.resource_fk = resource.resource_pk) AS load_balancer_addresses,
+              'AWS'                                         AS provider,
+              'AWS LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'ALB' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS ALB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS Application Load Balancer name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" resource-description="AWS Application Load Balancer name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" resource-description="DNS name of the load balancer" resource-description-manual="true" target-description="DNS Name"/>
+            <field resource="fqdn" source-type="string" target="fqdn" target-header="AWS LB" min-length="1" max-length="255" resource-description="Fully qualified domain name" resource-description-manual="true" target-description="FQDN"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="AWS LB" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <field resource="canonical_hosted_zone_id" source-type="string" target="canonical_hosted_zone_id" target-header="AWS LB" min-length="1" max-length="255" resource-description="Route 53 hosted zone ID for the load balancer" resource-description-manual="true" target-description="Canonical Hosted Zone ID"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS LB" resource-description="Current state of the load balancer" resource-description-manual="true" target-description="State"/>
+            <field resource="ip_address_type" source-type="string" target="ip_address_type" target-type="string" target-header="AWS LB" min-length="1" max-length="255" resource-description="IP address type (ipv4 or dualstack)" resource-description-manual="true" target-description="IP Address Type"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-header="AWS LB" min-length="1" max-length="255" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+            <field resource="scheme" source-type="string" target="scheme" target-header="AWS LB" min-length="1" max-length="255" resource-description="Load balancer scheme (internet-facing or internal)" resource-description-manual="true" target-description="Scheme"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS LB" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Created Time"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS LB" min-length="1" max-length="255" resource-description="VPC identifier" resource-description-manual="true" target-description="VPC ID"/>
+            <field resource="load_balancer_addresses" source-type="string" target="load_balancer_addresses" target-type="string" target-header="AWS LB" min-length="1" max-length="255" resource-description="IP addresses assigned to the load balancer" resource-description-manual="true" target-description="Load Balancer Addresses"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Subnet to Freshservice AWS Subnet" type="asset" description="Copy AWS Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              subnet.details ->> 'zone'                                                AS availability_zone,
+              subnet.details ->> 'vendor_subnet_id'                                    AS item_id,
+              subnet.details ->> 'vendor_available_ip_count'                           AS vendor_available_ip_count,
+              subnet.details ->> 'state'                                               AS state,
+              vrfgroup.name                                                            AS vpc_id,
+              infra.account_id                                                         AS owner_id,
+              'AWS'                                                                    AS provider,
+              'AWS Subnet'                                                             AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AWS Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Name of Subnet" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" resource-description="Name of Subnet" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255" resource-description="CIDR block address range" resource-description-manual="true" target-description="CIDR Block"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Subnet" resource-description="Current resource state" resource-description-manual="true" target-description="State"/>
+            <field resource="vendor_available_ip_count" source-type="integer" target="available_ip_address_count" target-type="integer" target-header="AWS Subnet" resource-description="Number of available IP addresses in the subnet" resource-description-manual="true" target-description="Available IP Address Count"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Subnet" min-length="1" max-length="255" resource-description="Name of VRF Group" target-description="VPC ID"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Subnet" min-length="1" max-length="255" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Owner ID"/>
+          </mapping>
+        </task>
+
+        <!-- AWS EC2 Security Group -->
+        <task enable="true" name="D42 AWS Security Group to Freshservice AWS Security Group" type="asset" description="Copy AWS Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'owner_id'                                            AS owner_id,
+              resource.details ->> 'vpc_id'                                              AS vpc_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'inbound_rule_count'                                  AS inbound_rules_count,
+              resource.details ->> 'outbound_rule_count'                                 AS outbound_rules_count,
+              'AWS'                                                                      AS provider,
+              'AWS Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS', 'security_group']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS Security Group name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true" resource-description="AWS Security Group name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="string" target-header="Cloud" min-length="1" max-length="255" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-header="AWS Security Group" min-length="1" max-length="255" resource-description="VPC identifier" resource-description-manual="true" target-description="VPC ID"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS Security Group" min-length="1" max-length="255" resource-description="AWS account ID of the resource owner" resource-description-manual="true" target-description="Owner ID"/>
+            <field resource="description" source-type="string" target="description" target-header="AWS Security Group" min-length="1" max-length="255" resource-description="User-provided description of the security group" resource-description-manual="true" target-description="Description"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" resource-description="Number of inbound security rules" resource-description-manual="true" target-description="Inbound Rules Count"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" resource-description="Number of outbound security rules" resource-description-manual="true" target-description="Outbound Rules Count"/>
+         </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS VPC to Freshservice AWS VPC" type="asset" description="Copy AWS VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name) AS name,
+              vrfgroup.name                                                    AS item_id,
+              CAST(vrfgroup.details ->> 'vendor_is_default' AS BOOLEAN)        AS is_it_default,
+              vrfgroup.details ->> 'region'                                    AS region,
+              vrfgroup.details ->> 'cidr_block'                                AS cidr_block,
+              vrfgroup.details ->> 'instance_tenancy'                          AS instance_tenancy,
+              vrfgroup.details ->> 'status'                                    AS state,
+              infra.account_id                                                 AS owner_id,
+              'AWS'                                                            AS provider,
+              'AWS VPC'                                                        AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                           AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="VPC name tag value" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" resource-description="VPC name tag value" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true" resource-description="Name of VRF Group" target-description="Item ID"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" min-length="1" max-length="255" resource-description="CIDR block address range" resource-description-manual="true" target-description="CIDR Block"/>
+
+            <!-- AWS VPC -->
+            <field resource="instance_tenancy" source-type="string" target="instance_tenancy" target-type="string" target-header="AWS VPC" resource-description="Default instance tenancy (default, dedicated, or host)" resource-description-manual="true" target-description="Instance Tenancy"/>
+            <field resource="is_it_default" source-type="boolean" target="is_default" target-type="boolean" target-header="AWS VPC" resource-description="Whether this is the default VPC" resource-description-manual="true" target-description="Is Default"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS VPC" resource-description="VPC state (available or pending)" resource-description-manual="true" target-description="State"/>
+            <field resource="owner_id" source-type="string" target="owner_id" target-header="AWS VPC" min-length="1" max-length="255" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Owner ID"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS RDS to Freshservice AWS RDS" type="asset" description="Copy AWS RDS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                                  AS name,
+              resource.details ->> 'db_instance_arn'                                                  AS item_id,
+              CASE
+                WHEN resource.region LIKE '%,%' THEN ''
+                ELSE resource.region
+              END                                                                                     AS region,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                     AS availability_zone,
+              listener.details ->> 'hosted_zone_id' AS hosted_zone_id,
+              (resource.details ->> 'creation_date')::timestamptz                                     AS created_time,
+              resource.details ->> 'db_instance_status'                                               AS state,
+              resource.details ->> 'engine_version'                                                   AS engine_version,
+              CAST(resource.details ->> 'storage_usable' AS NUMERIC) / 1024                           AS allocated_storage,
+              resource.details ->> 'max_allocated_storage'                                            AS max_allocated_storage,
+              CAST(resource.details ->> 'multi_az' AS BOOLEAN)                                        AS multiple_availablity_zone,
+              resource.details ->> 'license_model'                                                    AS license_model,
+              resource.details ->> 'cloud_compute_type'                                               AS database_class,
+              resource.details ->> 'preferred_maintenance_window'                                     AS maintenance_window,
+              CAST(resource.details ->> 'auto_minor_version_upgrade' AS BOOLEAN)                      AS auto_minor_version_upgrade,
+              resource.details ->> 'storage_type'                                                     AS storage_type,
+              CAST(resource.details ->> 'storage_is_encrypted' AS BOOLEAN)                            AS storage_is_encrypted,
+              CAST(resource.details ->> 'iam_database_authentication_enabled' AS BOOLEAN)             AS iam_database_authentication_enabled,
+              CAST(resource.details ->> 'deletion_protection' AS BOOLEAN)                             AS deletion_protection,
+              resource.details ->> 'kms_key_id'                                                       AS kms_key_id,
+              listener.fqdn                                                                           AS endpoint,
+              listener.port                                                                           AS port,
+              infra.account_id                                                                        AS owner_id,
+              'AWS'                                                                                   AS provider,
+              'AWS RDS'                                                                               AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                             AS device42_id
+            FROM
+             view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN ( SELECT resource_fk, fqdn, port, details FROM view_servicelistenerport_v2 WHERE servicelistenerport_pk in (
+              SELECT MIN(servicelistenerport_pk) FROM view_servicelistenerport_v2 WHERE ip IS NULL GROUP BY resource_fk)
+            ) listener on resource.resource_pk = listener.resource_fk
+            WHERE
+              resource.vendor_resource_type = 'RDS' AND NOT 'Cluster' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS RDS -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS RDS database instance name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Database" resource-description="AWS RDS database instance name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="state" source-type="string" target="database_status" target-type="dropdown" target-header="Database" resource-description="Current state of the database instance" resource-description-manual="true" target-description="Status"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="Database" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Created Time"/>
+            <field resource="engine_version" source-type="string" target="engine_version" target-type="string" target-header="Database" resource-description="Database engine version" resource-description-manual="true" target-description="Engine Version"/>
+            <field resource="allocated_storage" source-type="integer" target="allocated_storage" target-type="integer" target-header="Database" resource-description="Allocated storage size in GB" resource-description-manual="true" target-description="Allocated Storage (GiB)"/>
+            <field resource="max_allocated_storage" source-type="integer" target="max_allocated_storage" target-type="integer" target-header="Database" resource-description="Maximum storage size for autoscaling in GB" resource-description-manual="true" target-description="Max Allocated Storage (GiB)"/>
+            <field resource="multiple_availablity_zone" source-type="boolean" target="multiple_availablity_zone" target-type="boolean" target-header="Database" resource-description="Whether Multi-AZ deployment is enabled" resource-description-manual="true" target-description="Multi-AZ" target-description-manual="true"/>
+            <field resource="license_model" source-type="string" target="license_model" target-type="string" target-header="Database" resource-description="Database license model" resource-description-manual="true" target-description="License Model"/>
+            <field resource="database_class" source-type="string" target="database_class" target-type="dropdown" target-header="Database" resource-description="RDS instance class (e.g. db.m5.large)" resource-description-manual="true" target-description="Database Class"/>
+            <field resource="endpoint" source-type="string" target="endpoint" target-type="string" target-header="Database" resource-description="Database connection endpoint address" resource-description-manual="true" target-description="Endpoint"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="Database" resource-description="Database connection port number" resource-description-manual="true" target-description="Port"/>
+
+            <field resource="hosted_zone_id" source-type="string" target="hosted_zone_id" target-type="string" target-header="AWS RDS" min-length="1" max-length="255" resource-description="Route 53 hosted zone ID for the endpoint" resource-description-manual="true" target-description="Hosted Zone ID"/>
+            <field resource="maintenance_window" source-type="string" target="maintenance_window" target-header="AWS RDS" target-type="string" min-length="1" max-length="255" resource-description="Preferred maintenance window schedule" resource-description-manual="true" target-description="Maintenance Window"/>
+            <field resource="auto_minor_version_upgrade" source-type="boolean" target="auto_minor_version_upgrade" target-type="boolean" target-header="AWS RDS" resource-description="Whether automatic minor version upgrades are enabled" resource-description-manual="true" target-description="Auto Minor Version Upgrade"/>
+            <field resource="storage_type" source-type="string" target="storage_type" target-type="string" target-header="AWS RDS" resource-description="Storage type (gp2, gp3, io1, etc.)" resource-description-manual="true" target-description="Storage Type"/>
+            <field resource="storage_is_encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS RDS" resource-description="Whether storage encryption is enabled" resource-description-manual="true" target-description="Encrypted"/>
+            <field resource="iam_database_authentication_enabled" source-type="boolean" target="authentication_enabled" target-type="boolean" target-header="AWS RDS" resource-description="Whether IAM database authentication is enabled" resource-description-manual="true" target-description="Authentication Enabled"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-header="AWS RDS" target-type="string" min-length="1" max-length="255" resource-description="AWS KMS encryption key identifier" resource-description-manual="true" target-description="KMS Key ID"/>
+            <field resource="deletion_protection" source-type="boolean" target="deletion_protection" target-type="boolean" target-header="AWS RDS" resource-description="Whether deletion protection is enabled" resource-description-manual="true" target-description="Deletion Protection"/>
+            <field resource="owner_id" source-type="integer" target="account_id" target-header="AWS RDS" target-type="integer" min-length="1" max-length="255" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Account ID"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AZURE Subnet to Freshservice AZURE Subnet" type="asset" description="Copy AZURE Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              subnet.name                                                              AS name,
+              set_masklen(subnet.network, subnet.mask_bits)                            AS cidr_block,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  subnet.details ->> 'resource_group',
+                  '/',
+                  vrfgroup.name,
+                  '/',
+                  subnet.name
+              )                                                                        AS item_id,
+              subnet.details ->> 'provisioning_state'                                  AS provisioning_state,
+              subnet.details ->> 'resource_type'                                       AS resource_type,
+              subnet.details ->> 'resource_group'                                      AS resource_group,
+              subnet.details ->> 'location'                                            AS region,
+              vrfgroup.name                                                            AS network_name,
+              infra.account_id                                                         AS subscription_id,
+              'AZURE'                                                                  AS provider,
+              'Azure Subnet'                                                           AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                    AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND subnet.last_changed > '%s'">
+            <!-- AZURE Subnet -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Name of Subnet" target-description="Display Name"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" resource-description="Name of Subnet" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255" resource-description="CIDR block address range" resource-description-manual="true" target-description="CIDR Block"/>
+
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="string" target-header="Azure Subnet" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Subnet" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Subnet" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+            <field resource="network_name" source-type="string" target="network_name" target-type="string" target-header="Azure Subnet" resource-description="Name of VRF Group" target-description="Network Name"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Subnet" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Disk -->
+        <task enable="true" name="D42 Azure Disk to Freshservice Azure Disk" type="asset" description="Copy Azure Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                               AS name,
+              resource.identifier                                                  AS resource_uri,
+              resource.vendor_resource_subtype                                     AS instance_type,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                  AS availability_zone,
+              resource.details ->> 'location'                                      AS region,
+              resource.details ->> 'resource_guid'                                 AS item_id,
+              (resource.details ->> 'creation_date')::timestamptz                  AS created_time,
+              CASE
+                WHEN resource.details ->> 'state' = 'Unattached' THEN 'Available'
+                ELSE 'In-use'
+              END                                                                  AS state,
+              ((resource.details ->> 'storage_usable')::float / 1024.0)::text      AS storage_usable,
+              resource.details ->> 'storage_iops'                                  AS storage_iops,
+              resource.details ->> 'tier'                                          AS tier,
+              resource.details ->> 'sku_name'                                      AS sku_name,
+              resource.details ->> 'mbps_read_write'                               AS mbps_read_write,
+              resource.details ->> 'max_shares'                                    AS max_shares,
+              infra.account_id                                                     AS subscription_id,
+              'AZURE'                                                              AS provider,
+              'Azure Disk'                                                         AS asset_type,
+              format('Resource-%s', resource.resource_pk)                          AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure managed disk name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true" resource-description="Azure managed disk name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="instance_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" resource-description="Subtype of Resource such as aurora, mysql, etc" target-description="Volume Type"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" resource-description="Current state of the managed disk" resource-description-manual="true" target-description="State"/>
+            <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" resource-description="Usable storage capacity in GB" resource-description-manual="true" target-description="Size(GB)"/>
+            <field resource="storage_iops" source-type="string" target="iops" target-type="string" target-header="Volume" resource-description="Provisioned I/O operations per second" resource-description-manual="true" target-description="IOPS"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Disk" resource-description="Unique string to distinguish a resource from others in the system" target-description="Resource URI"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Disk" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+            <field resource="tier" source-type="string" target="disk_tier" target-type="string" target-header="Azure Disk" resource-description="Performance tier of the managed disk" resource-description-manual="true" target-description="Disk Tier"/>
+            <field resource="sku_name" source-type="string" target="sku_name" target-type="string" target-header="Azure Disk" resource-description="Azure SKU name" resource-description-manual="true" target-description="SKU Name"/>
+            <field resource="mbps_read_write" source-type="string" target="disk_mbps_read_write" target-type="string" target-header="Azure Disk" resource-description="Provisioned throughput in MB/s for read/write operations" resource-description-manual="true" target-description="Disk MBps Read Write"/>
+            <field resource="max_shares" source-type="string" target="max_shares" target-type="string" target-header="Azure Disk" resource-description="Maximum number of VMs that can attach this disk simultaneously" resource-description-manual="true" target-description="Max Shares"/>
+          </mapping>
+        </task>
+
+        <!-- Azure Security Group -->
+        <task enable="true" name="D42 Azure Security Group to Freshservice Azure Security Group" type="asset" description="Copy Azure Security Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS resource_uri,
+              resource.vendor_resource_subtype              AS instance_type,
+              resource.details ->> 'resource_guid'          AS item_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'location'               AS region,
+              resource.details ->> 'inbound_rules_count'    AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'   AS outbound_rules_count,
+              infra.account_id                              AS subscription_id,
+              'AZURE'                                       AS provider,
+              'Azure Security Group'                        AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Network Security Group'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure Network Security Group name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true" resource-description="Azure Network Security Group name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" resource-description="Number of inbound security rules" resource-description-manual="true" target-description="Inbound Rules Count"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" resource-description="Number of outbound security rules" resource-description-manual="true" target-description="Outbound Rules Count"/>
+
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Security Group" resource-description="Unique string to distinguish a resource from others in the system" target-description="Resource URI"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Security Group" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+            <field resource="instance_type" source-type="string" target="instance_type" target-type="string" target-header="Azure Security Group" resource-description="Subtype of Resource such as aurora, mysql, etc" target-description="Instance Type"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Security Group" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Security Group" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Subscription to Freshservice Azure Subscription" type="asset" description="Copy Azure Subscription from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              COALESCE(
+                NULLIF(infra.details ->> 'display_name', ''),
+                NULLIF(infra.cloudinfrastructure_name, ''),
+                infra.account_id
+              ) AS name,
+              infra.account_id                                                                               AS item_id,
+              infra.organization                                                                             AS tenant,
+              infra.details ->> 'state'                                                                      AS subscription_state,
+              infra.details ->> 'authorization_source'                                                       AS authorization_source,
+              infra.details ->> 'location_placement_id'                                                      AS location_placement_id,
+              infra.details ->> 'quota_id'                                                                   AS quota_id,
+              infra.details ->> 'spending_limit'                                                             AS spending_limit,
+              'AZURE'                                                                                        AS provider,
+              'Azure Subscription'                                                                           AS asset_type,
+              format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)                                 AS device42_id
+            FROM
+              view_cloudinfrastructure_v2 infra
+            LEFT JOIN
+              view_vendor_v1 vendor
+              ON infra.cloud_vendor_fk = vendor.vendor_pk 
+            WHERE vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND infra.last_changed > '%s'">
+            <!-- Azure Subscription -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure subscription display name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subscription" min-length="1" max-length="248" escape="true" resource-description="Azure subscription display name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subscription" error-skip="true" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Item ID"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="authorization_source" source-type="string" target="authorization_source" target-type="string" target-header="Azure Subscription" resource-description="Source of the subscription authorization" resource-description-manual="true" target-description="Authorization Source"/>
+            <field resource="tenant" source-type="string" target="tenant_id" target-type="string" target-header="Azure Subscription" resource-description="The organization that is discovered for the Cloud Account" target-description="Tenant ID"/>
+            <field resource="subscription_state" source-type="string" target="subscription_state" target-type="dropdown" target-header="Azure Subscription" min-length="1" max-length="255" resource-description="Current state of the Azure subscription" resource-description-manual="true" target-description="Subscription State"/>
+            <field resource="location_placement_id" source-type="string" target="location_placement_id" target-type="string" target-header="Azure Subscription" resource-description="Azure placement ID for the subscription location" resource-description-manual="true" target-description="Location Placement ID"/>
+            <field resource="quota_id" source-type="string" target="quota_id" target-type="string" target-header="Azure Subscription" resource-description="Azure subscription quota identifier" resource-description-manual="true" target-description="Quota ID"/>
+            <field resource="spending_limit" source-type="string" target="spending_limit" target-type="string" target-header="Azure Subscription" resource-description="Spending limit setting for the subscription" resource-description-manual="true" target-description="Spending Limit"/>
+         </mapping>
+        </task>
+
+        <!-- Azure Application Gateway -->
+        <task enable="true" name="D42 Azure Application Gateway to Freshservice Azure Application Gateway" type="asset" description="Copy Azure Application Gateway from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+            SELECT
+              resource.resource_name                                   AS name,
+              CONCAT(
+                  infra.account_id,
+                  '/',
+                  resource.details ->> 'resource_group',
+                  '/',
+                  resource.resource_name
+              )                                                        AS item_id,
+              resource.vendor_resource_subtype                         AS resource_type,
+              resource.details ->> 'resource_guid'                     AS resource_guid,
+              resource.details ->> 'provisioning_state'                AS provisioning_state,
+              resource.details ->> 'location'                          AS region,
+              resource.details ->> 'sku_name'                          AS sku_name,
+              resource.details ->> 'sku_tier'                          AS sku_tier,
+              resource.details ->> 'operational_state'                 AS operational_state,
+              (resource.details ->> 'enable_http2')::BOOLEAN           AS enable_http2,
+              (resource.details ->> 'autoscale_min_capacity')::INTEGER AS autoscale_min_capacity,
+              (resource.details ->> 'autoscale_max_capacity')::INTEGER AS autoscale_max_capacity,
+              infra.account_id                                         AS subscription_id,
+              'AZURE'                                                  AS provider,
+              'Azure Application Gateway'                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)              AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Application Gateway'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Application Gateway -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure Application Gateway name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Application Gateway" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Application Gateway" min-length="1" max-length="248" escape="true" resource-description="Azure Application Gateway name" resource-description-manual="true" target-description="Item Name"/>
+
+            <field resource="resource_guid" source-type="string" target="resource_guid" target-type="string" target-header="Azure Application Gateway" resource-description="Azure resource GUID" resource-description-manual="true" target-description="Resource GUID"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Application Gateway" resource-description="Subtype of Resource such as aurora, mysql, etc" target-description="Resource Type"/>
+            <field resource="provisioning_state" source-type="string" target="ag_provisioning_state" target-type="dropdown" target-header="Azure Application Gateway" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+            <field resource="sku_name" source-type="string" target="ag_sku_name" target-type="dropdown" target-header="Azure Application Gateway" resource-description="Azure SKU name" resource-description-manual="true" target-description="SKU Name"/>
+            <field resource="sku_tier" source-type="string" target="ag_sku_tier" target-type="dropdown" target-header="Azure Application Gateway" resource-description="Azure SKU pricing tier" resource-description-manual="true" target-description="SKU Tier"/>
+            <field resource="operational_state" source-type="string" target="operational_state" target-type="string" target-header="Azure Application Gateway" resource-description="Current operational state of the gateway" resource-description-manual="true" target-description="Operational State"/>
+            <field resource="enable_http2" source-type="boolean" target="enable_http2" target-type="boolean" target-header="Azure Application Gateway" resource-description="Whether HTTP/2 protocol is enabled" resource-description-manual="true" target-description="HTTP/2 Enabled" target-description-manual="true"/>
+            <field resource="autoscale_min_capacity" source-type="integer" target="minimum_capacity" target-type="integer" target-header="Azure Application Gateway" resource-description="Minimum autoscale capacity in instances" resource-description-manual="true" target-description="Minimum Capacity"/>
+            <field resource="autoscale_max_capacity" source-type="integer" target="maximum_capacity" target-type="integer" target-header="Azure Application Gateway" resource-description="Maximum autoscale capacity in instances" resource-description-manual="true" target-description="Maximum Capacity"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS EBS to Freshservice AWS EBS" type="asset" description="Copy AWS EBS from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                    AS name,
+              resource.identifier                                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)                               AS device42_id,
+              ci.account_id                                                             AS account_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                       AS availability_zone,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                                                       AS region,
+              ((resource.details ->> 'storage_usable')::integer / 1024)::text           AS size,
+              resource.details ->> 'state'                                              AS state,
+              (resource.details ->> 'creation_date')::timestamptz                       AS created_time,
+              resource.details ->> 'storage_iops'                                       AS iops,
+              resource.details ->> 'storage_type'                                       AS volume_type,
+              (resource.details ->> 'storage_is_encrypted')::boolean                    AS encrypted,
+              resource.details ->> 'multi_attach'                                       AS multi_attach_enabled,
+              resource.details ->> 'snapshot_id'                                        AS snapshot_id,
+              resource.details ->> 'throughput'                                         AS throughput,
+              resource.details ->> 'kms_key_id'                                         AS kms_key_id,
+              'AWS Disk'                                                                AS asset_type,
+              'AWS'                                                                     AS provider
+            FROM
+              view_resource_v2 resource
+            LEFT JOIN
+              view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EBS' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EBS General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS EBS volume name" resource-description-manual="true" target-description="Display Name"/>
+
+            <!-- AWS EBS Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+
+            <!-- AWS EBS Volume -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" resource-description="AWS EBS volume name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" resource-description="EBS volume size in GB" resource-description-manual="true" target-description="Size(GB)"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" resource-description="Volume type (gp2, gp3, io1, io2, st1, sc1, standard)" resource-description-manual="true" target-description="Volume Type"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" resource-description="Volume attachment state" resource-description-manual="true" target-description="State"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="iops" source-type="string" target="iops" target-type="string" target-header="Volume" resource-description="Provisioned IOPS for the volume" resource-description-manual="true" target-description="IOPS"/>
+
+            <!-- AWS EBS Disk -->
+            <field resource="account_id" source-type="integer" target="account_id" target-type="integer" target-header="AWS Disk" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Account ID"/>
+            <field resource="encrypted" source-type="boolean" target="cd_encrypted" target-type="boolean" target-header="AWS Disk" resource-description="Whether the volume is encrypted" resource-description-manual="true" target-description="Encrypted"/>
+            <field resource="kms_key_id" source-type="string" target="kms_key_id" target-type="string" target-header="AWS Disk" resource-description="AWS KMS encryption key identifier" resource-description-manual="true" target-description="KMS Key ID"/>
+            <field resource="snapshot_id" source-type="string" target="snapshot_id" target-type="string" target-header="AWS Disk" resource-description="Source snapshot ID the volume was created from" resource-description-manual="true" target-description="Snapshot ID"/>
+            <field resource="throughput" source-type="string" target="throughput" target-type="string" target-header="AWS Disk" resource-description="Provisioned throughput in MB/s" resource-description-manual="true" target-description="Throughput"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 EC2 Key Pair to Freshservice AWS Key Pair" type="asset" description="Copy AWS Key Pair from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              resource.identifier                                       AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              resource.region                                           AS region,
+              resource.details ->> 'fingerprint'                        AS fingerprint,
+              CASE
+                WHEN EXISTS (
+                    SELECT 1
+                        FROM view_deviceresource_v1 dr
+                        WHERE dr.resource_fk = resource.resource_pk
+                    ) THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                       AS state,
+              'AWS Key Pair'                                            AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'EC2 Key Pair' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS EC2 Key Pair -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="EC2 key pair name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Pair" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Pair" resource-description="EC2 key pair name" resource-description-manual="true" target-description="Item Name"/>
+
+            <field resource="fingerprint" source-type="string" target="finger_print" target-type="string" target-header="AWS Key Pair" resource-description="Key pair fingerprint" resource-description-manual="true" target-description="Fingerprint"/>
+            <field resource="state" source-type="string" target="key_pair_state" target-type="dropdown" target-header="AWS Key Pair" resource-description="Current resource state" resource-description-manual="true" target-description="State"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS S3 to Freshservice AWS S3" type="asset" description="Copy AWS S3 from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                    AS name,
+              REPLACE(resource.identifier, 'arn:aws:s3:::', '')         AS item_id,
+              format('Resource-%s', resource.resource_pk)               AS device42_id,
+              ci.account_id                                             AS account_id,
+              resource.region                                           AS region,
+              (resource.details ->> 'creation_date')::timestamptz       AS created_time,
+              resource.details ->> 'bucket_owner_name'                  AS owner_name,
+              resource.details ->> 'bucket_owner_id'                    AS owner_id,
+              'AWS S3 Bucket'                                           AS asset_type,
+              'AWS'                                                     AS provider
+            FROM
+               view_resource_v2 resource
+            LEFT JOIN
+               view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = resource.cloudinfrastructure_fk
+            WHERE
+              'S3' = resource.vendor_resource_type
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS S3 General -->
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS S3 bucket name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+
+            <!-- AWS S3 Cloud -->
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+
+            <!-- AWS S3 Object Storage -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Object Storage" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Object Storage" resource-description="AWS S3 bucket name" resource-description-manual="true" target-description="Item Name"/>
+
+            <!-- AWS S3 Bucket -->
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS S3 Bucket" resource-description="AWS account ID of the resource owner" resource-description-manual="true" target-description="Owner ID"/>
+            <field resource="owner_name" source-type="string" target="owner_name" target-type="string" target-header="AWS S3 Bucket" resource-description="Display name of the resource owner" resource-description-manual="true" target-description="Owner Name"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS S3 Bucket" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Created Time"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Public IP to Freshservice AWS Public IP" type="asset" description="Copy AWS Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource doql="
+            SELECT
+              COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+              NULLIF(ip.label, '')                                                       AS ip_name,
+              ip.ip_address                                                              AS item_id,
+              ip.ip_address                                                              AS public_ip,
+              CASE 
+                  WHEN NULLIF(ip.details ->> 'instance_id', '') IS NOT NULL THEN 'Attached'
+                  ELSE 'Unattached'
+              END AS state,
+              ip.details ->> 'domain'                                                    AS domain,
+              ip.details ->> 'allocation_id'                                             AS allocation_id,
+              ip.details ->> 'association_id'                                            AS association_id,
+              ip.details ->> 'instance_id'                                               AS instance_id,
+              ip.details ->> 'public_ipv4_pool'                                          AS public_ipv4_pool,
+              ip.details ->> 'private_ip_address'                                        AS private_ip,
+              ip.details ->> 'network_border_group'                                      AS network_border_group,
+              ip.details ->> 'network_interface_id'                                      AS network_interface_id,
+              ip.details ->> 'network_interface_owner_id'                                AS network_interface_owner_id,
+              ip.details ->> 'public_dns'                                                AS public_dns,
+              ip.details ->> 'region'                                                    AS region,
+              infra.account_id                                                           AS account_id,
+              'AWS'                                                                      AS provider,
+              'AWS Public IP Address'                                                    AS asset_type,
+              format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Elastic IP resource name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <!-- Public IP Address -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true" resource-description="IP Address - supports IPv4 and IPv6 and includes optional netmask data; for example 192 168 22 187/24 or 2001:db8:abcd:0012::/64)" target-description="Item ID"/>
+            <field resource="ip_name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" resource-description="The Elastic IP address itself" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" resource-description="IP Address - supports IPv4 and IPv6 and includes optional netmask data; for example 192 168 22 187/24 or 2001:db8:abcd:0012::/64)" target-description="Public IP"/>
+            <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" resource-description="Public DNS name associated with the IP address" resource-description-manual="true" target-description="Public DNS"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" resource-description="Current state of the Elastic IP" resource-description-manual="true" target-description="State"/>
+            <!-- AWS Public IP Address -->
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Public IP Address" resource-description="Cloud provider instance identifier" resource-description-manual="true" target-description="Instance Id"/>
+            <field resource="allocation_id" source-type="string" target="allocation_id" target-type="string" target-header="AWS Public IP Address" resource-description="Elastic IP allocation identifier" resource-description-manual="true" target-description="Allocation ID"/>
+            <field resource="domain" source-type="string" target="cd_domain" target-type="string" target-header="AWS Public IP Address" resource-description="IP address scope (vpc or standard/EC2-Classic)" resource-description-manual="true" target-description="Domain"/>
+            <field resource="network_interface_id" source-type="string" target="nic_id" target-type="string" target-header="AWS Public IP Address" resource-description="Associated network interface identifier" resource-description-manual="true" target-description="NIC ID"/>
+            <field resource="network_interface_owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Public IP Address" resource-description="AWS account ID of the network interface owner" resource-description-manual="true" target-description="Owner ID"/>
+            <field resource="public_ipv4_pool" source-type="string" target="public_ipv4_pool" target-type="string" target-header="AWS Public IP Address" resource-description="Public IPv4 address pool the IP was allocated from" resource-description-manual="true" target-description="Public IPv4 Pool"/>
+            <field resource="account_id" source-type="string" target="account_id" target-type="integer" target-header="AWS Public IP Address" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Account ID"/>
+            <field resource="private_ip" source-type="string" target="private_ip" target-type="string" target-header="AWS Public IP Address" resource-description="Primary private IPv4 address" resource-description-manual="true" target-description="Private IP"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 Azure VPC to Freshservice Azure VPC" type="asset" description="Copy Azure VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'resource_guid'                              AS item_id,
+              vrfgroup.details ->> 'region'                                     AS region,
+              vrfgroup.details ->> 'resource_id'                                AS resource_id,
+              vrfgroup.details ->> 'resource_type'                              AS resource_type,
+              vrfgroup.details ->> 'resource_group'                             AS resource_group,
+              (vrfgroup.details ->> 'ddos_protection')::boolean                 AS ddos_protection,
+              vrfgroup.details ->> 'provisioning_state'                         AS provisioning_state,
+              infra.account_id                                                  AS account_id,
+              (SELECT string_agg(value::text, ',')
+               FROM jsonb_array_elements_text(vrfgroup.details -> 'cidrs'))     AS cidr_block,
+              'AZURE'                                                           AS provider,
+              'Azure VPC'                                                       AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Virtual network name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" resource-description="Virtual network name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="VPC" min-length="1" max-length="255" resource-description="CIDR block address range" resource-description-manual="true" target-description="CIDR Block"/>
+
+            <!-- Azure VPC -->
+            <field resource="resource_id" source-type="string" target="resource_uri" target-type="string" target-header="Azure VPC" resource-description="Azure resource identifier URI" resource-description-manual="true" target-description="Resource URI"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure VPC" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure VPC" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure VPC" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+            <field resource="ddos_protection" source-type="boolean" target="ddos_protection" target-type="boolean" target-header="Azure VPC" resource-description="Whether Azure DDoS Protection is enabled" resource-description-manual="true" target-description="DDOS Protection"/>
+            <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure VPC" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP Subnet to Freshservice GCP Subnet" type="asset" description="Copy GCP Subnet from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)          AS name,
+              subnet.name                                                               AS item_id,
+              set_masklen(subnet.network, subnet.mask_bits)                             AS cidr_block,
+              subnet.details ->> 'self_link'                                            AS self_link,
+              SUBSTRING(subnet.details ->> 'self_link' FROM '/regions/([^/]+)')         AS region,
+              subnet.details ->> 'purpose'                                              AS purpose,
+              subnet.details ->> 'stack_type'                                           AS stack_type,
+              subnet.details ->> 'creation_timestamp'                                   AS creation_timestamp,
+              subnet.details ->> 'gateway_address'                                      AS gateway_address,
+              subnet.details ->> 'network_link'                                         AS network,
+              (subnet.details ->> 'private_ip_google_access')::boolean                  AS private_ip_google_access,
+              subnet.details ->> 'private_ipv6_google_access'                           AS private_ipv6_google_access,
+              infra.account_id                                                          AS owner_id,
+              'GCP'                                                                     AS provider,
+              'GCP Subnet'                                                              AS asset_type,
+              format('Subnet-%s', subnet.subnet_pk)                                     AS device42_id
+            FROM
+              view_subnet_v1 subnet
+            JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and subnet.last_changed > '%s'">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Subnet name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+
+            <!-- Subnet -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Subnet" resource-description="Subnet name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Subnet" error-skip="true" resource-description="Name of Subnet" target-description="Item ID"/>
+            <field resource="cidr_block" source-type="string" target="cidr_block" target-type="string" target-header="Subnet" min-length="1" max-length="255" resource-description="CIDR block address range" resource-description-manual="true" target-description="CIDR Block"/>
+
+            <!-- GCP Subnet -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Subnet" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Subnet" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+            <field resource="purpose" source-type="string" target="purpose" target-type="dropdown" target-header="GCP Subnet" min-length="1" max-length="255" resource-description="Subnet purpose (PRIVATE, REGIONAL_MANAGED_PROXY, etc.)" resource-description-manual="true" target-description="Purpose"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Subnet" resource-description="IP stack type (IPV4_ONLY or IPV4_IPV6)" resource-description-manual="true" target-description="Stack Type"/>
+            <field resource="gateway_address" source-type="string" target="gateway_address" target-type="string" target-header="GCP Subnet" resource-description="Default gateway IP address for the subnet" resource-description-manual="true" target-description="Gateway Address"/>
+            <field resource="network" source-type="string" target="network" target-type="string" target-header="GCP Subnet" resource-description="VPC network the subnet belongs to" resource-description-manual="true" target-description="Network"/>
+            <field resource="cidr_block" source-type="string" target="ip_cidr_range" target-type="string" target-header="GCP Subnet" min-length="1" max-length="255" resource-description="CIDR block address range" resource-description-manual="true" target-description="IP CIDR Range"/>
+            <field resource="private_ip_google_access" source-type="boolean" target="private_ip_google_access" target-type="boolean" target-header="GCP Subnet" resource-description="Whether VMs without external IPs can access Google APIs" resource-description-manual="true" target-description="Private IP Google Access"/>
+            <field resource="private_ipv6_google_access" source-type="string" target="private_ipv6_google_access" target-type="string" target-header="GCP Subnet" resource-description="Whether private IPv6 Google access is enabled" resource-description-manual="true" target-description="Private IPv6 Google Access"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP VPC to Freshservice GCP VPC" type="asset" description="Copy GCP VPC from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+             SELECT
+              coalesce(vrfgroup.vendor_custom_fields -> 'Name', vrfgroup.name)  AS name,
+              vrfgroup.details ->> 'id'                                         AS item_id,
+              (vrfgroup.details ->> 'creation_timestamp')::timestamptz          AS creation_timestamp,
+              vrfgroup.details ->> 'self_link'                                  AS self_link,
+              (vrfgroup.details ->> 'auto_create_subnetworks')::boolean         AS auto_create_subnetworks,
+              vrfgroup.details ->> 'routing_mode'                               AS routing_mode,
+              vrfgroup.details ->> 'firewall_policy_enforcement_order'          AS firewall_policy_enforcement_order,
+              vrfgroup.details ->> 'description'                                AS description,
+              'global'                                                          AS region,
+              'GCP'                                                             AS provider,
+              'GCP VPC'                                                         AS asset_type,
+              format('VPC-%s', vrfgroup.vrfgroup_pk)                            AS device42_id
+            FROM
+              view_vrfgroup_v1 vrfgroup
+            JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name">
+            <!-- General/Cloud -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="VPC network name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <!-- VPC -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="VPC" resource-description="VPC network name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="VPC" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <!-- GCP VPC -->
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP VPC" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP VPC" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+            <field resource="auto_create_subnetworks" source-type="string" target="auto_create_subnetworks" target-type="boolean" target-header="GCP VPC" resource-description="Whether subnets are auto-created in each region" resource-description-manual="true" target-description="Auto Create Subnetworks"/>
+            <field resource="routing_mode" source-type="string" target="routing_mode" target-type="string" target-header="GCP VPC" resource-description="Network routing mode (REGIONAL or GLOBAL)" resource-description-manual="true" target-description="Routing Mode"/>
+            <field resource="firewall_policy_enforcement_order" source-type="string" target="network_firewall_policy_enforcement_order" target-type="dropdown" target-header="GCP VPC" resource-description="Order in which firewall policies are evaluated" resource-description-manual="true" target-description="Network Firewall Policy Enforcement Order"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP VPC" resource-description="User-provided description of the VPC network" resource-description-manual="true" target-description="Description"/>
+          </mapping>
+      </task>
+
+      <!-- GCP Disk -->
+      <task enable="true" name="D42 GCP Disk to Freshservice GCP Disk" type="asset" description="Copy GCP Disk from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+          doql="
+             SELECT
+              resource.resource_name                                                                           AS name,
+              split_part(resource.identifier, ':', array_length(string_to_array(resource.identifier, ':'), 1)) AS item_id,
+              CASE
+                WHEN array_to_string(resource.zones, ',', '*') ILIKE '%,%' THEN ''
+                ELSE array_to_string(resource.zones, ',', '*')
+              END                                                                                              AS availability_zone,
+              resource.region                                                                                  AS region,
+              (resource.details ->> 'created')::timestamptz                                                    AS created_time,
+              (resource.details ->> 'last_attached')::timestamptz                                              AS last_attached,
+              resource.details ->> 'source_image'                                                              AS source_image,
+              resource.details ->> 'self_link'                                                                 AS self_link,
+              resource.details ->> 'state'                                                                     AS state,
+              ((resource.details ->> 'size')::float / 1024.0 / 1024.0 / 1024.0)::text                          AS volume_size,
+              resource.details ->> 'kind'                                                                      AS kind,
+              resource.details ->> 'volume_type'                                                               AS volume_type,
+              resource.details ->> 'physical_block_size'                                                       AS physical_block_size,
+              infra.account_id                                                                                 AS subscription_id,
+              'GCP'                                                                                            AS provider,
+              'GCP Disk'                                                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                                      AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Disk -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="GCP persistent disk name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="availability_zone" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" min-length="1" max-length="248" escape="true" resource-description="GCP persistent disk name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="created_time" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="Volume" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" min-length="1" max-length="255" resource-description="Current state of the persistent disk" resource-description-manual="true" target-description="State"/>
+            <field resource="volume_size" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" resource-description="Persistent disk capacity in GB" resource-description-manual="true" target-description="Size(GB)"/>
+            <field resource="volume_type" source-type="string" target="volume_type" target-type="string" target-header="Volume" resource-description="Volume type (gp2, gp3, io1, io2, st1, sc1, standard)" resource-description-manual="true" target-description="Volume Type"/>
+
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Disk" resource-description="GCP resource kind identifier" resource-description-manual="true" target-description="Kind"/>
+            <field resource="last_attached" source-type="datetime" target="last_attach_timestamp" target-type="datetime" target-header="GCP Disk" resource-description="Date and time the disk was last attached to a VM" resource-description-manual="true" target-description="Last Attach Timestamp"/>
+            <field resource="source_image" source-type="string" target="source_image" target-type="string" target-header="GCP Disk" resource-description="Source image used to create the disk" resource-description-manual="true" target-description="Source Image"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Disk" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+            <field resource="physical_block_size" source-type="integer" target="physical_block_size_bytes" target-type="integer" target-header="GCP Disk" resource-description="Physical block size in bytes" resource-description-manual="true" target-description="Physical Block Size Bytes"/>
+          </mapping>
+        </task>
+
+         <!-- GCP Security Group, AKA GCP Firewall Rules -->
+        <task enable="true" name="D42 GCP Firewall Rules to Freshservice GCP Security Group" type="asset" description="Copy GCP Firewall Rules from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              'global'                                                                   AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'network'                                             AS network,
+              (resource.details ->> 'disabled')::boolean                                 AS disabled,
+              resource.details ->> 'priority'                                            AS priority,
+              resource.details ->> 'direction'                                           AS direction,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'target_tags'                                         AS target_tags,
+              resource.details ->> 'source_ranges'                                       AS source_ranges,
+              resource.details ->> 'destination_ranges'                                  AS destination_ranges,
+              (resource.details ->> 'created_timestamp')::timestamptz                    AS created_timestamp,
+              resource.details ->> 'inbound_rules_count'                                 AS inbound_rules_count,
+              resource.details ->> 'outbound_rules_count'                                AS outbound_rules_count,
+              resource.details ->> 'log_config_enabled'                                  AS log_config_enabled,
+              resource.details ->> 'allowed_ip_protocols'                                AS allowed_ip_protocols,
+              resource.details ->> 'denied_ip_protocols'                                 AS denied_ip_protocols,
+              'GCP'                                                                      AS provider,
+              'GCP Security Group'                                                       AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['gcp_firewall_rule']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Security Group -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="GCP firewall rule name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Security Group" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Security Group" min-length="1" max-length="248" escape="true" resource-description="GCP firewall rule name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="inbound_rules_count" source-type="integer" target="inbound_rules_count" target-type="integer" target-header="Security Group" resource-description="Number of inbound security rules" resource-description-manual="true" target-description="Inbound Rules Count"/>
+            <field resource="outbound_rules_count" source-type="integer" target="outbound_rules_count" target-type="integer" target-header="Security Group" resource-description="Number of outbound security rules" resource-description-manual="true" target-description="Outbound Rules Count"/>
+            <field resource="created_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Security Group" min-length="1" max-length="255" resource-description="Date and time when the firewall rule was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="priority" source-type="string" target="priority" target-type="integer" target-header="GCP Security Group" resource-description="Rule priority (lower number = higher priority, range 0-65535)" resource-description-manual="true" target-description="Priority"/>
+            <field resource="direction" source-type="string" target="direction" target-type="string" target-header="GCP Security Group" resource-description="Rule traffic direction (INGRESS or EGRESS)" resource-description-manual="true" target-description="Direction"/>
+            <field resource="disabled" source-type="boolean" target="disabled" target-type="boolean" target-header="GCP Security Group" resource-description="Whether the firewall rule is currently disabled" resource-description-manual="true" target-description="Disabled"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Security Group" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+            <field resource="description" source-type="string" target="description" target-header="GCP Security Group" resource-description="User-provided description of the firewall rule" resource-description-manual="true" target-description="Description"/>
+            <field resource="source_ranges" source-type="string" target="source_ranges" target-header="GCP Security Group" resource-description="Source CIDR ranges the rule applies to" resource-description-manual="true" target-description="Source Ranges"/>
+            <field resource="destination_ranges" source-type="string" target="destination_ranges" target-header="GCP Security Group" resource-description="Destination CIDR ranges the rule applies to" resource-description-manual="true" target-description="Destination Ranges"/>
+            <field resource="allowed_ip_protocols" source-type="string" target="allowed_ip_protocols" target-header="GCP Security Group" resource-description="IP protocols and ports allowed by this rule" resource-description-manual="true" target-description="Allowed IP Protocols"/>
+            <field resource="denied_ip_protocols" source-type="string" target="denied_ip_protocols" target-header="GCP Security Group" resource-description="IP protocols and ports denied by this rule" resource-description-manual="true" target-description="Denied IP Protocols"/>
+            <field resource="log_config_enabled" source-type="string" target="log_config_enabled" target-type="string" target-header="GCP Security Group" resource-description="Whether firewall rule logging is enabled" resource-description-manual="true" target-description="Log Config Enabled"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="CPU Components" type="component" description="Copy CPU Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Processor' as component_type,
+                            ven.name as vendor_name,
+                            pm.speed || ' ' || pm.speed_unit as speed,
+                            pm.cores::character varying as cores,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model,
+                            (pm.cores::integer * pm.threads::integer)::character varying as logical_processor,
+                            case when threads > 1 then 'Yes' else 'No' end as hyperthread
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'CPU' and device_fk is not null and ven.name is not null and pm.speed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Manufacturer" target-description-manual="true"/>
+                <field resource="speed" source-type="string" target="cpu_speed" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component clock speed" resource-description-manual="true" target-description="CPU Speed(GHz)"/>
+                <field resource="cores" source-type="string" target="no_of_cores" target-type="string"
+                       min-length="1" max-length="255" resource-description="Number of CPU cores per socket" resource-description-manual="true" target-description="Number of Cores" target-description-manual="true"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component or hardware model name" resource-description-manual="true" target-description="Model" target-description-manual="true"/>
+                <field resource="cores" source-type="string" target="cores_per_socket" target-type="string"
+                       min-length="1" max-length="255" resource-description="Number of CPU cores per socket" resource-description-manual="true" target-description="Cores per Socket" target-description-manual="true"/>
+                <field resource="logical_processor" source-type="string" target="logical_processor" target-type="string"
+                       min-length="1" max-length="255" resource-description="Number of logical processors (threads)" resource-description-manual="true" target-description="Logical Processors" target-description-manual="true"/>
+                <field resource="hyperthread" source-type="string" target="hyperthread" target-type="string"
+                       min-length="1" max-length="255" resource-description="Whether CPU hyperthreading is enabled" resource-description-manual="true" target-description="Hyperthreading" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="RAM Components" type="component" description="Copy RAM Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Memory' as component_type,
+                            pt.slot as socket,
+                            pm.ramsize || ' ' || pm.ramsize_unit as capacity,
+                            pm.ramtype,
+                            pm.ramspeed::character varying as ramspeed,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'RAM' and device_fk is not null and pt.slot is not null and pt.slot != ''
+                                   and ven.name is not null and pm.ramsize is not null and pm.ramspeed is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Manufacturer" target-description-manual="true"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component or hardware model name" resource-description-manual="true" target-description="Model" target-description-manual="true"/>
+                <field resource="socket" source-type="string" target="socket" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Slot for Part" target-description="Socket" target-description-manual="true"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component storage or tray capacity" resource-description-manual="true" target-description="Size(GB)"/>
+                <field resource="ramtype" source-type="string" target="memory_type" target-type="string"
+                       min-length="1" max-length="255" resource-description="RAM Type for Parts Model" target-description="Memory Type" target-description-manual="true"/>
+                <field resource="ramspeed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="RAM clock speed" resource-description-manual="true" target-description="Speed" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Network Adapter Components" type="component" description="Copy Network Adapter from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            with network_ip as (
+                                   select
+                                   vip.device_fk,
+                                   vip.netport_fk,
+                                   string_agg(host(vip.ip_address)::character varying, ', ' order by vip.ip_address) as ip_address,
+                                   string_agg(host(vip.network)::character varying, ', ' order by vip.ip_address) as network,
+                                   string_agg(vip.mask_bits::character varying, ', ' order by vip.ip_address) as mask_bits
+                                   from (select distinct device_fk, netport_fk, ip_address, view_subnet_v1.network, view_subnet_v1.mask_bits
+                                          from view_ipaddress_v1 left join view_subnet_v1 on view_ipaddress_v1.subnet_fk = view_subnet_v1.subnet_pk) vip group by vip.device_fk, vip.netport_fk)
+                            select
+                            format('Device-%s', dev.device_pk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Network Adapter' as component_type,
+                            np.hwaddress,
+                            network_ip.ip_address,
+                            network_ip.network,
+                            network_ip.mask_bits,
+                            np.port,
+                            case when ven.name is not null then ven.name else 'N/A' end vendor_name,
+                            'N/A' as model,
+                            np.port_speed
+                            from view_netport_v1 np
+                            join view_device_v1 dev on np.device_fk = dev.device_pk
+                            join network_ip on network_ip.device_fk = dev.device_pk and network_ip.netport_fk=np.netport_pk
+                            left join view_vendor_v1 ven on ven.vendor_pk = np.vendor_fk
+                            where hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12 and network_ip.ip_address is not null
+                            order by np.device_fk, np.netport_pk
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Vendor or manufacturer name" resource-description-manual="true" target-description="Manufacturer" target-description-manual="true"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component or hardware model name" resource-description-manual="true" target-description="Model" target-description-manual="true"/>
+                <field resource="ip_address" source-type="string" target="ip_addr" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="IP address assigned to the network adapter" resource-description-manual="true" target-description="IP Address" target-description-manual="true"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="port" source-type="string" target="nic" target-type="string"
+                       min-length="1" max-length="255" resource-description="Network adapter port identifier" resource-description-manual="true" target-description="NIC Port" target-description-manual="true"/>
+                <field resource="network" source-type="string" target="network" target-type="string"
+                       min-length="1" max-length="255" resource-description="Network or VLAN the adapter is connected to" resource-description-manual="true" target-description="Network"/>
+                <field resource="mask_bits" source-type="string" target="subnet_mask" target-type="string"
+                       min-length="1" max-length="255" resource-description="Subnet mask in CIDR notation (bits)" resource-description-manual="true" target-description="Subnet Mask"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       min-length="1" max-length="255" resource-description="Network adapter link speed" resource-description-manual="true" target-description="Speed" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Hard Disk Components" type="component" description="Copy Hard Disk Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                            format('Device-%s', pt.device_fk) as asset_device42_id,
+                            dev.name as device_name,
+                            'Hard Disk' as component_type,
+                            CASE
+                                   WHEN pm.hdsize_unit = 'GB' THEN pm.hdsize
+                                   WHEN pm.hdsize_unit = 'TB' THEN pm.hdsize * 1024
+                                   WHEN pm.hdsize_unit = 'PB' THEN pm.hdsize * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'EB' THEN pm.hdsize * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'ZB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024
+                                   WHEN pm.hdsize_unit = 'YB' THEN pm.hdsize * 1024 * 1024 * 1024 * 1024 * 1024
+                            END::character varying as capacity,
+                            pm.hdrpm_name,
+                            ven.name as vendor_name,
+                            CONCAT_WS(' ',  pm.type_name, pm.name, pm.modelno, pm.partno) as model
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            left join view_vendor_v1 ven on pm.vendor_fk=ven.vendor_pk
+                            where pm.type_name = 'Hard Disk' and pm.hdsize is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="vendor_name" source-type="string" target="manufacturer" target-type="string"
+                       min-length="1" max-length="255" resource-description="Name of Vendor (or Manufacturer) - If EnrichAI is enabled, this will contain the enriched value - otherwise it will be the discovered or manually overwritten value" target-description="Manufacturer" target-description-manual="true"/>
+                <field resource="model" source-type="string" target="model" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component or hardware model name" resource-description-manual="true" target-description="Model" target-description-manual="true"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Component storage or tray capacity" resource-description-manual="true" target-description="Size(GB)"/>
+                <field resource="hdrpm_name" source-type="string" target="rpm" target-type="string"
+                       min-length="1" max-length="255" resource-description="Speed(RPM) for HD RPM" target-description="RPM" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Logical Drive Components" type="component" description="Copy Mount Point(Logical Drive) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Logical Drive' as component_type,
+                                   mp.mountpoint,
+                                   mp.fstype_name,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where not (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="drive_name" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Mount Point" target-description="Drive Name" target-description-manual="true"/>
+                <field resource="fstype_name" source-type="string" target="file_type" target-type="string"
+                       min-length="1" max-length="255" resource-description="Name for Filesystem Type" target-description="File Type" target-description-manual="true"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255" resource-description="Component storage or tray capacity" resource-description-manual="true" target-description="Size(GB)"/>
+                <field resource="free_capacity" source-type="string" target="free_space" target-type="string"
+                       min-length="1" max-length="255" resource-description="Available free capacity" resource-description-manual="true" target-description="Free Space(GB)"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Datastore Components" type="component" description="Copy Mount Point(Datastore) from Device42 to Freshservice using DOQL">
+            <api>
+                <target/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', dev.device_pk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Datastore' as component_type,
+                                   mp.mountpoint,
+                                   mp.filesystem,
+                                   round(mp.capacity / 1024, 2)::character varying as capacity,
+                                   round(mp.free_capacity / 1024, 2)::character varying as free_capacity
+                            from (select * from view_mountpoint_v2 mp, unnest(mp.device_fks) device_fk) mp
+                            join view_device_v1 dev on mp.device_fk = dev.device_pk
+                            where (dev.virtual_host AND lower(dev.os_name) like '%esxi%')
+                                   and mp.capacity is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="mountpoint" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Mount Point" target-description="Display Name"/>
+                <field resource="filesystem" source-type="string" target="location" target-type="string"
+                       min-length="1" max-length="255" resource-description="Filesystem for Mount Point" target-description="Location" target-description-manual="true"/>
+                <field resource="capacity" source-type="string" target="capacity" target-type="string"
+                       min-length="1" max-length="255" resource-description="Component storage or tray capacity" resource-description-manual="true" target-description="Size(GB)"/>
+                <field resource="free_capacity" source-type="string" target="freespace" target-type="string"
+                       min-length="1" max-length="255" resource-description="Available free capacity" resource-description-manual="true" target-description="Free Space" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Input" type="component" description="Copy Printer Input Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Input Units' as component_type,
+                                   pt.details ->> 'input_name' as name,
+                                   pt.details ->> 'input_type' as input_type,
+                                   pt.details ->> 'input_capacity' as max_capacity,
+                                   pt.details ->> 'input_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_input' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'input_name'), '') is not null and nullif(trim(pt.details ->> 'input_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Printer input tray name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="input_type" source-type="string" target="type" target-type="integer"
+                       required="true" resource-description="Printer input tray type" resource-description-manual="true" target-description="Type">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="sheetFeedAutoRemovableTray" value="3"/>
+                        <item key="sheetFeedAutoNonRemovableTray" value="4"/>
+                        <item key="sheetFeedManual" value="5"/>
+                        <item key="continuousRoll" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer" resource-description="Maximum tray or marker capacity" resource-description-manual="true" target-description="Maximum Capacity" target-description-manual="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer" resource-description="Current fill or ink level" resource-description-manual="true" target-description="Current Level" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Output" type="component" description="Copy Printer Output Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Output Units' as component_type,
+                                   pt.details ->> 'output_name' as name,
+                                   pt.details ->> 'output_type' as output_type,
+                                   pt.details ->> 'output_capacity' as max_capacity,
+                                   pt.details ->> 'output_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_output' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'output_name'), '') is not null and nullif(trim(pt.details ->> 'output_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Printer output tray name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="output_type" source-type="string" target="type" target-type="integer"
+                       required="true" resource-description="Printer output tray type" resource-description-manual="true" target-description="Type">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="removableBin" value="3"/>
+                        <item key="unRemovableBin" value="4"/>
+                        <item key="continuousRollDevice" value="5"/>
+                        <item key="mailBox" value="6"/>
+                        <item key="continuousFanFold" value="7"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer" resource-description="Maximum tray or marker capacity" resource-description-manual="true" target-description="Maximum Capacity" target-description-manual="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer" resource-description="Current fill or ink level" resource-description-manual="true" target-description="Current Level" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Printer Marker" type="component" description="Copy Printer Marker Parts from Device42 to Freshservice using DOQL">
+            <api>
+                <target asset-type="Printer"/>
+                <resource
+                          doql="
+                            select
+                                   format('Device-%s', pt.device_fk) as asset_device42_id,
+                                   dev.name as device_name,
+                                   'Marker Supply Units' as component_type,
+                                   pt.details ->> 'marker_name' as name,
+                                   pt.details ->> 'marker_type' as marker_type,
+                                   pt.details ->> 'marker_capacity' as max_capacity,
+                                   pt.details ->> 'marker_current_level' as current_level
+                            from view_part_v1 pt
+                            join view_device_v1 dev on pt.device_fk = dev.device_pk
+                            join view_partmodel_v1 pm on pt.partmodel_fk=pm.partmodel_pk
+                            where lower(pm.type_name) = 'printer_marker' and device_fk is not null
+                                   and nullif(trim(pt.details ->> 'marker_name'), '') is not null and nullif(trim(pt.details ->> 'marker_type'), '') is not null
+                            "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="name" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Printer marker (toner/ink) name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="marker_type" source-type="string" target="type" target-type="integer"
+                       required="true" resource-description="Printer marker (toner/ink) type" resource-description-manual="true" target-description="Type">
+                    <value-mapping default="2">
+                        <item key="other" value="1"/>
+                        <item key="unknown" value="2"/>
+                        <item key="toner" value="3"/>
+                        <item key="wasteToner" value="4"/>
+                        <item key="ink" value="5"/>
+                        <item key="inkCartridge" value="6"/>
+                        <item key="inkRibbon" value="7"/>
+                        <item key="wasteInk" value="8"/>
+                        <item key="opc" value="9"/>
+                        <item key="developer" value="10"/>
+                        <item key="fuserOil" value="11"/>
+                        <item key="solidWax" value="12"/>
+                        <item key="ribbonWax" value="13"/>
+                        <item key="wasteWax" value="14"/>
+                        <item key="fuser" value="15"/>
+                        <item key="coronaWire" value="16"/>
+                        <item key="fuserOilWick" value="17"/>
+                        <item key="cleanerUnit" value="18"/>
+                        <item key="fuserCleaningPad" value="19"/>
+                        <item key="transferUnit" value="20"/>
+                        <item key="tonerCartridge" value="21"/>
+                        <item key="fuserOiler" value="22"/>
+                        <item key="water" value="23"/>
+                        <item key="wasteWater" value="24"/>
+                        <item key="glueWaterAdditive" value="25"/>
+                        <item key="wastePaper" value="26"/>
+                        <item key="bindingSupply" value="27"/>
+                        <item key="bandingSupply" value="28"/>
+                        <item key="stitchingWire" value="29"/>
+                        <item key="shrinkWrap" value="30"/>
+                        <item key="paperWrap" value="31"/>
+                        <item key="staples" value="32"/>
+                        <item key="inserts" value="33"/>
+                        <item key="covers" value="34"/>
+                    </value-mapping>
+                </field>             
+                <field resource="max_capacity" source-type="string" target="max_capacity" target-type="integer" resource-description="Maximum tray or marker capacity" resource-description-manual="true" target-description="Maximum Capacity" target-description-manual="true"/>
+                <field resource="current_level" source-type="string" target="current_level" target-type="integer" resource-description="Current fill or ink level" resource-description-manual="true" target-description="Current Level" target-description-manual="true"/>
+            </mapping>
+        </task>
+
+        <task enable="true" name="Interface Components" type="component" description="Copy Interface Component from Device42 to Freshservice using DOQL" d42_min_version="19.04.00">
+            <api>
+                <target asset-type="Switch,Router,Firewall,Printer,Access Point"/>
+                <!--
+                     Below are the rules for determining the device type in the Interface Components task:
+                     1. Check the physical subtype FIRST (highest priority)
+                     2. Check the fw_device_type checks SECOND
+                     3. Check the network_device flag (consistent with Devices task which maps network_device=true to Switch)
+                -->
+                <resource
+                          doql="
+                        select
+                               format('Device-%s', dev.device_pk) as asset_device42_id,
+                               dev.name as device_name,
+                               'Interface' as component_type,
+                               np.description,
+                               np.hwaddress,
+                               np.port_speed,
+                               np.type_name,
+                               np.up_admin,
+                               np.up
+                        from 
+                            (
+                                select 
+                                   netport_pk,
+                                   device_fk,
+                                   case when description is not null and LENGTH(TRIM(description)) > 0 then description
+                                   else name end as description,
+                                   hwaddress,
+                                   port_speed,
+                                   type_name,
+                                   up_admin,
+                                   up
+                                from view_netport_v1
+                            ) np
+                        join view_device_v2 dev on np.device_fk = dev.device_pk
+                        where np.description is not null and length(trim(np.description)) > 0
+                        and hwaddress is not null and LENGTH(TRIM(hwaddress)) = 12
+                        and (
+                            (lower(dev.type) = 'physical' AND lower(dev.physicalsubtype) IN ('network printer', 'router', 'firewall', 'access point'))
+                            OR
+                            lower(dev.details->>'fw_device_type') IN ('printer', 'router', 'firewall', 'access point', 'switch')
+                            OR
+                            dev.network_device = true
+                        )
+                        order by np.device_fk, np.netport_pk
+                        "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="asset_device42_id"/>
+            </matching>
+            <mapping>
+                <field resource="description" source-type="string" target="name" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Interface description or display name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="hwaddress" source-type="string" target="mac_address" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="MAC address of the network interface" resource-description-manual="true" target-description="MAC Address"/>
+                <field resource="port_speed" source-type="string" target="speed" target-type="string"
+                       required="true" min-length="1" max-length="255" resource-description="Network port speed" resource-description-manual="true" target-description="Speed" target-description-manual="true"/>
+                <field resource="type_name" source-type="string" target="type" target-type="integer"
+                       required="true" resource-description="Interface type name" resource-description-manual="true" target-description="Type">
+                    <value-mapping default="1">
+                        <item key="other" value="1"/>
+                        <item key="regular1822" value="2"/>
+                        <item key="hdh1822" value="3"/>
+                        <item key="ddnX25" value="4"/>
+                        <item key="rfc877x25" value="5"/>
+                        <item key="ethernetCsmacd" value="6"/>
+                        <item key="iso88023Csmacd" value="7"/>
+                        <item key="iso88024TokenBus" value="8"/>
+                        <item key="iso88025TokenRing" value="9"/>
+                        <item key="iso88026Man" value="10"/>
+                        <item key="starLan" value="11"/>
+                        <item key="proteon10Mbit" value="12"/>
+                        <item key="proteon80Mbit" value="13"/>
+                        <item key="hyperchannel" value="14"/>
+                        <item key="fddi" value="15"/>
+                        <item key="lapb" value="16"/>
+                        <item key="sdlc" value="17"/>
+                        <item key="ds1" value="18"/>
+                        <item key="e1" value="19"/>
+                        <item key="basicISDN" value="20"/>
+                        <item key="primaryISDN" value="21"/>
+                        <item key="propPointToPointSerial" value="22"/>
+                        <item key="ppp" value="23"/>
+                        <item key="softwareLoopback" value="24"/>
+                        <item key="eon" value="25"/>
+                        <item key="ethernet3Mbit" value="26"/>
+                        <item key="nsip" value="27"/>
+                        <item key="slip" value="28"/>
+                        <item key="ultra" value="29"/>
+                        <item key="ds3" value="30"/>
+                        <item key="sip" value="31"/>
+                        <item key="frameRelay" value="32"/>
+                        <item key="rs232" value="33"/>
+                        <item key="para" value="34"/>
+                        <item key="arcnet" value="35"/>
+                        <item key="arcnetPlus" value="36"/>
+                        <item key="atm" value="37"/>
+                        <item key="miox25" value="38"/>
+                        <item key="sonet" value="39"/>
+                        <item key="x25ple" value="40"/>
+                        <item key="iso88022llc" value="41"/>
+                        <item key="localTalk" value="42"/>
+                        <item key="smdsDxi" value="43"/>
+                        <item key="frameRelayService" value="44"/>
+                        <item key="v35" value="45"/>
+                        <item key="hssi" value="46"/>
+                        <item key="hippi" value="47"/>
+                        <item key="modem" value="48"/>
+                        <item key="aal5" value="49"/>
+                        <item key="sonetPath" value="50"/>
+                        <item key="sonetVT" value="51"/>
+                        <item key="smdsIcip" value="52"/>
+                        <item key="propVirtual" value="53"/>
+                        <item key="propMultiplexor" value="54"/>
+                        <item key="ieee80212" value="55"/>
+                        <item key="fibreChannel" value="56"/>
+                        <item key="hippiInterface" value="57"/>
+                        <item key="frameRelayInterconnect" value="58"/>
+                        <item key="aflane8023" value="59"/>
+                        <item key="aflane8025" value="60"/>
+                        <item key="cctEmul" value="61"/>
+                        <item key="fastEther" value="62"/>
+                        <item key="isdn" value="63"/>
+                        <item key="v11" value="64"/>
+                        <item key="v36" value="65"/>
+                        <item key="g703at64k" value="66"/>
+                        <item key="g703at2mb" value="67"/>
+                        <item key="qllc" value="68"/>
+                        <item key="fastEtherFX" value="69"/>
+                        <item key="channel" value="70"/>
+                        <item key="ieee80211" value="71"/>
+                        <item key="ibm370parChan" value="72"/>
+                        <item key="escon" value="73"/>
+                        <item key="dlsw" value="74"/>
+                        <item key="isdns" value="75"/>
+                        <item key="isdnu" value="76"/>
+                        <item key="lapd" value="77"/>
+                        <item key="ipSwitch" value="78"/>
+                        <item key="rsrb" value="79"/>
+                        <item key="atmLogical" value="80"/>
+                        <item key="ds0" value="81"/>
+                        <item key="ds0Bundle" value="82"/>
+                        <item key="bsc" value="83"/>
+                        <item key="async" value="84"/>
+                        <item key="cnr" value="85"/>
+                        <item key="iso88025Dtr" value="86"/>
+                        <item key="eplrs" value="87"/>
+                        <item key="arap" value="88"/>
+                        <item key="propCnls" value="89"/>
+                        <item key="hostPad" value="90"/>
+                        <item key="termPad" value="91"/>
+                        <item key="frameRelayMPI" value="92"/>
+                        <item key="x213" value="93"/>
+                        <item key="adsl" value="94"/>
+                        <item key="radsl" value="95"/>
+                        <item key="sdsl" value="96"/>
+                        <item key="vdsl" value="97"/>
+                        <item key="iso88025CRFPInt" value="98"/>
+                        <item key="myrinet" value="99"/>
+                        <item key="voiceEM" value="100"/>
+                        <item key="voiceFXO" value="101"/>
+                        <item key="voiceFXS" value="102"/>
+                        <item key="voiceEncap" value="103"/>
+                        <item key="voiceOverIp" value="104"/>
+                        <item key="atmDxi" value="105"/>
+                        <item key="atmFuni" value="106"/>
+                        <item key="atmIma" value="107"/>
+                        <item key="pppMultilinkBundle" value="108"/>
+                        <item key="ipOverCdlc" value="109"/>
+                        <item key="ipOverClaw" value="110"/>
+                        <item key="stackToStack" value="111"/>
+                        <item key="virtualIpAddress" value="112"/>
+                        <item key="mpc" value="113"/>
+                        <item key="ipOverAtm" value="114"/>
+                        <item key="iso88025Fiber" value="115"/>
+                        <item key="tdlc" value="116"/>
+                        <item key="gigabitEthernet" value="117"/>
+                        <item key="hdlc" value="118"/>
+                        <item key="lapf" value="119"/>
+                        <item key="v37" value="120"/>
+                        <item key="x25mlp" value="121"/>
+                        <item key="x25huntGroup" value="122"/>
+                        <item key="transpHdlc" value="123"/>
+                        <item key="interleave" value="124"/>
+                        <item key="fast" value="125"/>
+                        <item key="ip" value="126"/>
+                        <item key="docsCableMaclayer" value="127"/>
+                        <item key="docsCableDownstream" value="128"/>
+                        <item key="docsCableUpstream" value="129"/>
+                        <item key="a12MppSwitch" value="130"/>
+                        <item key="tunnel" value="131"/>
+                        <item key="coffee" value="132"/>
+                        <item key="ces" value="133"/>
+                        <item key="atmSubInterface" value="134"/>
+                        <item key="l2vlan" value="135"/>
+                        <item key="l3ipvlan" value="136"/>
+                        <item key="l3ipxvlan" value="137"/>
+                        <item key="digitalPowerline" value="138"/>
+                        <item key="mediaMailOverIp" value="139"/>
+                        <item key="dtm" value="140"/>
+                        <item key="dcn" value="141"/>
+                        <item key="ipForward" value="142"/>
+                        <item key="msdsl" value="143"/>
+                        <item key="ieee1394" value="144"/>
+                        <item key="if-gsn" value="145"/>
+                        <item key="dvbRccMacLayer" value="146"/>
+                        <item key="dvbRccDownstream" value="147"/>
+                        <item key="dvbRccUpstream" value="148"/>
+                        <item key="atmVirtual" value="149"/>
+                        <item key="mplsTunnel" value="150"/>
+                        <item key="srp" value="151"/>
+                        <item key="voiceOverAtm" value="152"/>
+                        <item key="voiceOverFrameRelay" value="153"/>
+                        <item key="idsl" value="154"/>
+                        <item key="compositeLink" value="155"/>
+                        <item key="ss7SigLink" value="156"/>
+                        <item key="propWirelessP2P" value="157"/>
+                        <item key="frForward" value="158"/>
+                        <item key="rfc1483" value="159"/>
+                        <item key="usb" value="160"/>
+                        <item key="ieee8023adLag" value="161"/>
+                        <item key="bgppolicyaccounting" value="162"/>
+                        <item key="frf16MfrBundle" value="163"/>
+                        <item key="h323Gatekeeper" value="164"/>
+                        <item key="h323Proxy" value="165"/>
+                        <item key="mpls" value="166"/>
+                        <item key="mfSigLink" value="167"/>
+                        <item key="hdsl2" value="168"/>
+                        <item key="shdsl" value="169"/>
+                        <item key="ds1FDL" value="170"/>
+                        <item key="pos" value="171"/>
+                        <item key="dvbAsiIn" value="172"/>
+                        <item key="dvbAsiOut" value="173"/>
+                        <item key="plc" value="174"/>
+                        <item key="nfas" value="175"/>
+                        <item key="tr008" value="176"/>
+                        <item key="gr303RDT" value="177"/>
+                        <item key="gr303IDT" value="178"/>
+                        <item key="isup" value="179"/>
+                        <item key="propDocsWirelessMaclayer" value="180"/>
+                        <item key="propDocsWirelessDownstream" value="181"/>
+                        <item key="propDocsWirelessUpstream" value="182"/>
+                        <item key="hiperlan2" value="183"/>
+                        <item key="propBWAp2Mp" value="184"/>
+                        <item key="sonetOverheadChannel" value="185"/>
+                        <item key="digitalWrapperOverheadChannel" value="186"/>
+                        <item key="aal2" value="187"/>
+                        <item key="radioMAC" value="188"/>
+                        <item key="atmRadio" value="189"/>
+                        <item key="imt" value="190"/>
+                        <item key="mvl" value="191"/>
+                        <item key="reachDSL" value="192"/>
+                        <item key="frDlciEndPt" value="193"/>
+                        <item key="atmVciEndPt" value="194"/>
+                        <item key="opticalChannel" value="195"/>
+                        <item key="opticalTransport" value="196"/>
+                        <item key="propAtm" value="197"/>
+                        <item key="voiceOverCable" value="198"/>
+                        <item key="infiniband" value="199"/>
+                        <item key="teLink" value="200"/>
+                        <item key="q2931" value="201"/>
+                        <item key="virtualTg" value="202"/>
+                        <item key="sipTg" value="203"/>
+                        <item key="sipSig" value="204"/>
+                        <item key="docsCableUpstreamChannel" value="205"/>
+                        <item key="econet" value="206"/>
+                        <item key="pon155" value="207"/>
+                        <item key="pon622" value="208"/>
+                        <item key="bridge" value="209"/>
+                        <item key="linegroup" value="210"/>
+                        <item key="voiceEMFGD" value="211"/>
+                        <item key="voiceFGDEANA" value="212"/>
+                        <item key="voiceDID" value="213"/>
+                        <item key="mpegTransport" value="214"/>
+                        <item key="sixToFour" value="215"/>
+                        <item key="gtp" value="216"/>
+                        <item key="pdnEtherLoop1" value="217"/>
+                        <item key="pdnEtherLoop2" value="218"/>
+                        <item key="opticalChannelGroup" value="219"/>
+                        <item key="homepna" value="220"/>
+                        <item key="gfp" value="221"/>
+                        <item key="ciscoISLvlan" value="222"/>
+                        <item key="actelisMetaLOOP" value="223"/>
+                        <item key="fcipLink" value="224"/>
+                        <item key="rpr" value="225"/>
+                        <item key="qam" value="226"/>
+                        <item key="lmp" value="227"/>
+                        <item key="cblVectaStar" value="228"/>
+                        <item key="docsCableMCmtsDownstream" value="229"/>
+                        <item key="adsl2" value="230"/>
+                        <item key="macSecControlledIF" value="231"/>
+                        <item key="macSecUncontrolledIF" value="232"/>
+                        <item key="aviciOpticalEther" value="233"/>
+                        <item key="atmbond" value="234"/>
+                        <item key="voiceFGDOS" value="235"/>
+                        <item key="mocaVersion1" value="236"/>
+                        <item key="ieee80216WMAN" value="237"/>
+                        <item key="adsl2plus" value="238"/>
+                        <item key="dvbRcsMacLayer" value="239"/>
+                        <item key="dvbTdm" value="240"/>
+                        <item key="dvbRcsTdma" value="241"/>
+                        <item key="x86Laps" value="242"/>
+                        <item key="wwanPP" value="243"/>
+                        <item key="wwanPP2" value="244"/>
+                        <item key="voiceEBS" value="245"/>
+                        <item key="ifPwType" value="246"/>
+                        <item key="ilan" value="247"/>
+                        <item key="pip" value="248"/>
+                        <item key="aluELP" value="249"/>
+                        <item key="gpon" value="250"/>
+                        <item key="vdsl2" value="251"/>
+                        <item key="capwapDot11Profile" value="252"/>
+                        <item key="capwapDot11Bss" value="253"/>
+                        <item key="capwapWtpVirtualRadio" value="254"/>
+                        <item key="bits" value="255"/>
+                        <item key="docsCableUpstreamRfPort" value="256"/>
+                        <item key="cableDownstreamRfPort" value="257"/>
+                        <item key="vmwareVirtualNic" value="258"/>
+                        <item key="ieee802154" value="259"/>
+                        <item key="otnOdu" value="260"/>
+                        <item key="otnOtu" value="261"/>
+                        <item key="ifVfiType" value="262"/>
+                        <item key="g9981" value="263"/>
+                        <item key="g9982" value="264"/>
+                        <item key="g9983" value="265"/>
+                        <item key="aluEpon" value="266"/>
+                        <item key="aluEponOnu" value="267"/>
+                        <item key="aluEponPhysicalUni" value="268"/>
+                        <item key="aluEponLogicalLink" value="269"/>
+                        <item key="aluGponOnu" value="270"/>
+                        <item key="aluGponPhysicalUni" value="271"/>
+                        <item key="vmwareNicTeam" value="272"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up_admin" source-type="boolean" target="admin_status" target-type="string"
+                       required="true" resource-description="Administrative status of the interface (up/down)" resource-description-manual="true" target-description="Administrative Status" target-description-manual="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+                <field resource="up" source-type="boolean" target="operator_status" target-type="string"
+                       required="true" resource-description="Operational status of the interface (up/down)" resource-description-manual="true" target-description="Operational Status" target-description-manual="true">
+                    <value-mapping default="1">
+                        <item key="true" value="1"/>
+                        <item key="false" value="2"/>
+                    </value-mapping>
+                </field>             
+            </mapping>
+        </task>
+
+        <task enable="true" name="D42 GCP LB to Freshservice GCP LB" type="asset" description="Copy GCP LB from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              CASE
+              WHEN resource.region LIKE '%,%' THEN ''
+              ELSE resource.region
+              END                                           AS region,
+              array_to_string(resource.zones, ',', '*')     AS availability_zone,
+              ''                                            AS dns_name,
+              resource.details ->> 'load_balancing_scheme'  AS load_balancing_scheme,
+              resource.details ->> 'max_utilization'        AS max_utilization,
+              resource.details ->> 'port'                   AS port,
+              resource.details ->> 'protocol'               AS protocol,
+              resource.details ->> 'port_name'              AS port_name,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              resource.details ->> 'balancing_mode'         AS balancing_mode,
+              resource.details ->> 'capacity_scaler'        AS capacity_scaler,
+              resource.details ->> 'timeout'                AS timeout,
+              resource.details ->> 'connection_draining_timeout' AS connection_draining_timeout,
+              (resource.details ->> 'enable_cdn')::boolean  AS enable_cdn,
+              (resource.details ->> 'log_config_enable')::boolean AS log_config_enable,
+              resource.details ->> 'locality_lb_policy'     AS locality_lb_policy,
+              'GCP'                                         AS provider,
+              'GCP LB'                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_load_balancer' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP LB -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="GCP load balancer name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255" resource-description="Region or zone where the load balancer operates" resource-description-manual="true" target-description="Availability Zone" target-description-manual="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Load Balancer" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255" resource-description="GCP load balancer name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="dns_name" source-type="string" target="dns_name" target-type="string" target-header="Load Balancer" min-length="1" max-length="255" resource-description="DNS name of the load balancer" resource-description-manual="true" target-description="DNS Name"/>
+            <field resource="load_balancing_scheme" source-type="string" target="load_balancing_scheme" target-type="dropdown" target-header="GCP LB" min-length="1" max-length="255" resource-description="Load balancing scheme (EXTERNAL, INTERNAL, etc.)" resource-description-manual="true" target-description="Load Balancing Scheme"/>
+            <field resource="port" source-type="integer" target="cd_port" target-type="integer" target-header="GCP LB" resource-description="Backend service port number" resource-description-manual="true" target-description="Port"/>
+            <field resource="protocol" source-type="string" target="protocol" target-type="dropdown" target-header="GCP LB" resource-description="Protocol used by the backend service (HTTP, HTTPS, TCP, etc.)" resource-description-manual="true" target-description="Protocol"/>
+            <field resource="port_name" source-type="string" target="port_name" target-type="string" target-header="GCP LB" min-length="1" max-length="255" resource-description="Named port for the backend service" resource-description-manual="true" target-description="Port Name"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP LB" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="balancing_mode" source-type="string" target="balancing_mode" target-type="string" target-header="GCP LB" min-length="1" max-length="255" resource-description="Backend balancing mode (UTILIZATION, RATE, or CONNECTION)" resource-description-manual="true" target-description="Balancing Mode"/>
+            <field resource="max_utilization" source-type="string" target="max_utilization" target-type="string" target-header="GCP LB" min-length="1" max-length="255" resource-description="Maximum backend utilization threshold (0.0 to 1.0)" resource-description-manual="true" target-description="Max Utilization"/>
+            <field resource="capacity_scaler" source-type="integer" target="capacity_scaler" target-type="string" target-header="GCP LB" min-length="1" max-length="255" resource-description="Backend capacity scaling factor (0.0 to 1.0)" resource-description-manual="true" target-description="Capacity Scaler"/>
+            <field resource="timeout" source-type="integer" target="timeout" target-type="integer" target-header="GCP LB" resource-description="Backend service timeout in seconds" resource-description-manual="true" target-description="Timeout"/>
+            <field resource="connection_draining_timeout" source-type="integer" target="connection_draining_timeout" target-type="integer" target-header="GCP LB" resource-description="Connection draining timeout in seconds" resource-description-manual="true" target-description="Connection Draining Timeout"/>
+            <field resource="enable_cdn" source-type="boolean" target="enable_cdn" target-type="boolean" target-header="GCP LB" resource-description="Whether Cloud CDN is enabled for this backend" resource-description-manual="true" target-description="Enable CDN"/>
+            <field resource="log_config_enable" source-type="boolean" target="log_config_enable" target-type="boolean" target-header="GCP LB" resource-description="Whether access logging is enabled" resource-description-manual="true" target-description="Log Config Enable"/>
+            <field resource="locality_lb_policy" source-type="string" target="locality_lb_policy" target-type="dropdown" target-header="GCP LB" resource-description="Locality-based load balancing policy" resource-description-manual="true" target-description="Locality LB Policy"/>
+            <!-- ~GCP LB -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Images to Freshservice Azure Images" type="asset" description="Copy Azure Images from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              resource.region                               AS region,
+              ''                                            AS availability_zone,
+              resource.details ->> 'guest_os'               AS guest_os,
+              resource.details ->> 'os_state'               AS os_state,
+              resource.details ->> 'provisioning_state'     AS provisioning_state,
+              resource.details ->> 'subscription_id'        AS subscription_id,
+              resource.details ->> 'resource_group'         AS resource_group,
+              resource.details ->> 'resource_type'          AS resource_type,
+              resource.details ->> 'image_source'           AS image_source,
+              'AZURE'                                       AS provider,
+              'Azure Image'                                 AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'azure_image' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure VM image name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone" target-description-manual="true"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true " min-length="1" max-length="255" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="255" resource-description="Azure VM image name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" min-length="1" max-length="255" resource-description="Source of the image" resource-description-manual="true" target-description="Image Source"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" resource-description="Guest operating system name" resource-description-manual="true" target-description="Guest OS"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Image" min-length="1" max-length="255" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+            <field resource="os_state" source-type="string" target="os_state" target-type="dropdown" target-header="Azure Image" resource-description="OS state of the image (Generalized or Specialized)" resource-description-manual="true" target-description="OS State"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Image" min-length="1" max-length="255" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Image" min-length="1" max-length="255" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Image" min-length="1" max-length="255" resource-description="Azure subscription identifier" resource-description-manual="true" target-description="Subscription ID"/>
+            <!-- ~Azure Image -->
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 Azure Network Interface to Freshservice Azure Network Interface" type="asset" description="Copy Azure Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                    AS name,
+              netport.port                                    AS item_name,
+              netport.details ->> 'resource_guid'             AS item_id,
+              netport.details ->> 'private_ip'                AS private_ip,
+              netport.details ->> 'state'                     AS state,
+              netport.details ->> 'resource_uri'              AS resource_uri,
+              netport.details ->> 'provisioning_state'        AS provisioning_state,
+              (netport.details ->> 'primary')::boolean                   AS primary,
+              'Standard'                                      AS nic_type,
+              netport.details ->> 'resource_type'             AS resource_type,
+              netport.details ->> 'resource_group'            AS resource_group,
+              netport.details ->> 'location'                  AS region,
+              netport.hwaddress                               AS mac_address,
+              infra.account_id                                AS subscription_id,
+              'AZURE'                                         AS provider,
+              'Azure Network Interface'                       AS asset_type,
+              format('Netport-%s', netport.netport_pk)        AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure network interface name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" resource-description="Azure network interface name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" resource-description="Azure network interface item name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" resource-description="Network interface MAC address" resource-description-manual="true" target-description="MAC Address"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" resource-description="Primary private IPv4 address" resource-description-manual="true" target-description="Private IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255" resource-description="Current resource state" resource-description-manual="true" target-description="State"/>
+            <field resource="resource_uri" source-type="string" target="resource_uri" target-type="string" target-header="Azure Network Interface" resource-description="Azure resource URI" resource-description-manual="true" target-description="Resource URI"/>
+            <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+            <field resource="primary" source-type="boolean" target="primary" target-type="boolean" target-header="Azure Network Interface" resource-description="Whether this is the primary network interface" resource-description-manual="true" target-description="Primary"/>
+            <field resource="nic_type" source-type="string" target="nic_type" target-type="dropdown" target-header="Azure Network Interface" min-length="1" max-length="255" resource-description="Network interface type (Standard or Elastic)" resource-description-manual="true" target-description="NIC Type"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Network Interface" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+            <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Network Interface" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+            <field resource="subscription_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Network Interface" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 AWS Network Interface to Freshservice AWS Network Interface" type="asset" description="Copy AWS Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)                      AS name,
+              netport.port                                                                                    AS item_id,
+              netport.details ->> 'private_ip'                                                                AS private_ip,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_ips')), ' ') AS secondary_ips,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'ipv6_ips')), ' ')      AS ipv6_ips,
+              netport.details ->> 'vpc_id'                                              AS vpc_id,
+              netport.details ->> 'state'                                               AS state,
+              netport.details ->> 'mac_address'                                         AS mac_address,
+              netport.details ->> 'attachment_id'                                       AS attachment_id,
+              (netport.details ->> 'attachment_time')::timestamptz                      AS attachment_time,
+              netport.details ->> 'attachment_status'                                   AS attachment_status,
+              netport.details ->> 'requester_id'                                        AS requester_id,
+              (netport.details ->> 'requester_managed')::boolean                        AS requester_managed,
+              netport.details ->> 'private_dns_name'                                    AS private_dns_name,
+              array_to_string(ARRAY(SELECT jsonb_array_elements_text(netport.details->'secondary_dns_names')), ' ')
+                                                                                        AS secondary_dns_names,
+              (netport.details ->> 'source_dest_check')::boolean                        AS source_dest_check,
+              netport.details ->> 'network_card_index'                                  AS network_card_index,
+              (netport.details ->> 'delete_on_termination')::boolean                    AS delete_on_termination,
+              netport.details ->> 'region'                                              AS region,
+              netport.details ->> 'availability_zone'                                   AS zone,
+              CASE
+                  WHEN netport.details ->> 'attachment_status' = 'attached' THEN 'Attached'
+                  ELSE 'Unattached'
+              END                                                                       AS state,
+              ci.instance_id                                                            AS instance_id,
+              infra.account_id                                                          AS owner_id,
+
+              'AWS'                                                                     AS provider,
+              'AWS Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            LEFT JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            LEFT JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            LEFT JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            LEFT JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+           <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS network interface name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone of the network interface" resource-description-manual="true" target-description="Availability Zone"/>
+
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" resource-description="AWS network interface name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true" resource-description="Network interface instance identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="private_ip" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" resource-description="Primary private IPv4 address" resource-description-manual="true" target-description="Private IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255" resource-description="Current resource state" resource-description-manual="true" target-description="State"/>
+            <field resource="mac_address" source-type="string" target="mac_address" target-type="string" target-header="Network Interface" resource-description="MAC address of the network interface" resource-description-manual="true" target-description="MAC Address"/>
+
+            <field resource="attachment_time" source-type="datetime" target="attachment_time" target-type="datetime" target-header="AWS Network Interface" min-length="1" max-length="255" resource-description="Date and time when the interface was attached" resource-description-manual="true" target-description="Attachment Time"/>
+            <field resource="attachment_id" source-type="string" target="attachment_id" target-type="string" target-header="AWS Network Interface" resource-description="Network interface attachment identifier" resource-description-manual="true" target-description="Attachment ID"/>
+            <field resource="delete_on_termination" source-type="boolean" target="delete_on_termination" target-type="boolean" target-header="AWS Network Interface" resource-description="Whether the interface is deleted when the instance terminates" resource-description-manual="true" target-description="Delete On Termination"/>
+            <field resource="network_card_index" source-type="integer" target="network_card_index" target-type="integer" target-header="AWS Network Interface" resource-description="Network card index for the attachment" resource-description-manual="true" target-description="Network Card Index"/>
+            <field resource="instance_id" source-type="string" target="instance_id" target-type="string" target-header="AWS Network Interface" resource-description="Unique Cloud Instance Identifier generated by the Cloud Provider upon creation" target-description="Instance Id"/>
+            <field resource="attachment_status" source-type="string" target="attachment_status" target-type="dropdown" target-header="AWS Network Interface" min-length="1" max-length="255" resource-description="Attachment state (attaching, attached, detaching, detached)" resource-description-manual="true" target-description="Attachment Status"/>
+
+            <field resource="owner_id" source-type="string" target="owner_id" target-type="string" target-header="AWS Network Interface" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Owner ID"/>
+            <field resource="private_dns_name" source-type="string" target="private_dns_name" target-type="string" target-header="AWS Network Interface" resource-description="Private DNS hostname within the VPC" resource-description-manual="true" target-description="Private DNS Name"/>
+            <field resource="secondary_dns_names" source-type="string" target="secondary_private_dns_names" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255" resource-description="Secondary private DNS names" resource-description-manual="true" target-description="Secondary Private DNS Names"/>
+            <field resource="secondary_ips" source-type="string" target="secondary_private_ip_addresses" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255" resource-description="Secondary private IPv4 addresses" resource-description-manual="true" target-description="Secondary Private IP Addresses"/>
+            <field resource="ipv6_ips" source-type="string" target="ipv6_addresses" target-type="string" target-header="AWS Network Interface" min-length="1" max-length="255" resource-description="IPv6 addresses associated with the interface" resource-description-manual="true" target-description="IPv6 Addresses"/>
+            <field resource="requester_id" source-type="string" target="requester_id" target-type="string" target-header="AWS Network Interface" resource-description="ID of the entity that launched the managed interface" resource-description-manual="true" target-description="Requester ID"/>
+            <field resource="requester_managed" source-type="boolean" target="requester_managed" target-type="boolean" target-header="AWS Network Interface" resource-description="Whether the interface is managed by AWS on behalf of a service" resource-description-manual="true" target-description="Requester Managed"/>
+            <field resource="source_dest_check" source-type="boolean" target="source_destination_check" target-type="boolean" target-header="AWS Network Interface" resource-description="Whether source/destination check is enabled" resource-description-manual="true" target-description="Source Destination Check"/>
+            <field resource="vpc_id" source-type="string" target="vpc_id" target-type="string" target-header="AWS Network Interface" resource-description="VPC identifier" resource-description-manual="true" target-description="VPC ID"/>
+          </mapping>
+        </task>
+
+         <task enable="true" name="D42 GCP Network Interface to Freshservice GCP Network Interface" type="asset" description="Copy GCP Network Interface from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              netport.port                                                              AS name,
+              CONCAT(ci.instance_id, '_', netport.port)                                 AS item_id,
+              netport.details ->> 'network_ip'                                          AS private_ip_address,
+              'Attached'                                                                AS state,
+              netport.details ->> 'stack_type'                                          AS stack_type,
+              netport.details ->> 'nat_ip'                                              AS public_ip_addresses,
+              netport.details ->> 'nat_ip'                                              AS nat_ip,
+              netport.details ->> 'access_type'                                         AS type,
+              ci.location                                                               AS zone,
+              ci.region                                                                 AS region,
+              'GCP'                                                                     AS provider,
+              'GCP Network Interface'                                                   AS asset_type,
+              format('Netport-%s', netport.netport_pk)                                  AS device42_id
+            FROM
+              view_netport_v1 netport
+            JOIN view_device_v2 as device     ON device.device_pk     = netport.device_fk
+            JOIN view_cloudinstance_v1 as ci ON ci.device_fk = device.device_pk
+            JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE infra.account_id is not null AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" and netport.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="GCP network interface name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="The Physical Region that the Cloud Instance is hosted (eg us-west, europe-north2, or ap-northeast-1)" target-description="Region"/>
+            <field resource="zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud Instance Location within Region (also known as an Availability Zone)" target-description="Availability Zone"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network Interface" resource-description="GCP network interface name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network Interface" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="private_ip_address" source-type="string" target="private_ip_address" target-type="string" target-header="Network Interface" resource-description="Primary private IPv4 address" resource-description-manual="true" target-description="Private IP Address"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Network Interface" min-length="1" max-length="255" resource-description="Current resource state" resource-description-manual="true" target-description="State"/>
+            <field resource="stack_type" source-type="string" target="stack_type" target-type="string" target-header="GCP Network Interface" min-length="1" max-length="255" resource-description="IP stack type (IPV4_ONLY or IPV4_IPV6)" resource-description-manual="true" target-description="Stack Type"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP Network Interface" min-length="1" max-length="255" resource-description="Resource type classification" resource-description-manual="true" target-description="Type"/>
+            <field resource="public_ip_addresses" source-type="string" target="public_ip_addresses" target-type="string" target-header="GCP Network Interface" resource-description="Public IP addresses assigned to the interface" resource-description-manual="true" target-description="Public IP Addresses"/>
+            <field resource="nat_ip" source-type="string" target="nat_ip" target-type="string" target-header="GCP Network Interface" resource-description="NAT IP address for external access" resource-description-manual="true" target-description="Nat IP"/>
+            <field resource="private_ip_address" source-type="string" target="network_ip" target-type="string" target-header="GCP Network Interface" resource-description="Primary private IPv4 address" resource-description-manual="true" target-description="Network IP"/>
+          </mapping>
+        </task>
+
+
+        <!-- Azure Resource Groups -->
+        <task enable="true" name="D42 Azure Resource Group to Freshservice Resource Group" type="asset" description="Copy Azure Resource Group from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              REGEXP_REPLACE(resource.identifier,'^/subscriptions/([^/]+)/resourceGroups/([^/]+)$', '\1/\2') AS item_id,
+              resource.details ->> 'resource_type'                                       AS resource_type,
+              resource.details ->> 'provisioning_state'                                  AS provisioning_state,
+              resource.details ->> 'region_name'                                         AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Resource Group'                                                     AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['resource_group', 'Azure']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Resource Groups -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure resource group name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Group" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Group" min-length="1" max-length="248" escape="true" resource-description="Azure resource group name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Resource Group" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+            <field resource="provisioning_state" source-type="string" target="provisioning_state" target-type="string" target-header="Azure Resource Group" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+         </mapping>
+       </task>
+
+       <!-- AWS Image -->
+        <task enable="true" name="D42 AWS Image to Freshservice AWS Image" type="asset" description="Copy AWS Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.region                                                            AS region,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'image_location'                                      AS image_source,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              (resource.details ->> 'creation_date')::timestamptz                        AS created_time,
+              resource.details ->> 'image_type'                                          AS image_type,
+              resource.details ->> 'state'                                               AS state,
+              resource.details ->> 'hypervisor'                                          AS hypervisor,
+              resource.details ->> 'root_device_name'                                    AS root_device_name,
+              resource.details ->> 'root_device_type'                                    AS root_device_type,
+              resource.details ->> 'virtualization_type'                                 AS virtualization_type,
+              resource.details ->> 'is_public'                                           AS is_public,
+              'AWS'                                                                      AS provider,
+              'AWS Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['AWS Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- AWS Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS AMI image name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="description" source-type="string" target="description" target-header="General" resource-description="User-provided description" resource-description-manual="true" target-description="Description"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true" resource-description="AWS AMI image name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" resource-description="Source of the image" resource-description-manual="true" target-description="Image Source"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" resource-description="Guest operating system name" resource-description-manual="true" target-description="Guest OS"/>
+            <field resource="created_time" source-type="datetime" target="created_time" target-type="datetime" target-header="AWS Image" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Created Time"/>
+            <field resource="image_type" source-type="string" target="image_type" target-type="dropdown" target-header="AWS Image" resource-description="Image type (machine, kernel, ramdisk)" resource-description-manual="true" target-description="Image Type"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="AWS Image" resource-description="Current resource state" resource-description-manual="true" target-description="State"/>
+            <field resource="hypervisor" source-type="string" target="hypervisor" target-type="string" target-header="AWS Image" resource-description="Hypervisor software name and version" resource-description-manual="true" target-description="Hypervisor"/>
+            <field resource="root_device_name" source-type="string" target="root_device_name" target-type="string" target-header="AWS Image" resource-description="Root device name (e.g. /dev/sda1, /dev/xvda)" resource-description-manual="true" target-description="Root Device Name"/>
+            <field resource="root_device_type" source-type="string" target="root_device_type" target-type="dropdown" target-header="AWS Image" resource-description="Root device type (ebs or instance-store)" resource-description-manual="true" target-description="Root Device Type"/>
+            <!-- -->
+            <field resource="virtualization_type" source-type="string" target="virtualization_type" target-type="dropdown" target-header="AWS Image" resource-description="Virtualization type (hvm or paravirtual)" resource-description-manual="true" target-description="Virtualization Type"/>
+            <field resource="is_public" source-type="string" target="public" target-type="boolean" target-header="AWS Image" resource-description="Whether the resource is publicly accessible" resource-description-manual="true" target-description="Public"/>
+         </mapping>
+     </task>
+
+    <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to Freshservice" d42_min_version="19.04.10" d42_max_version="19.04.99">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))                        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Public IP resource name" resource-description-manual="true" target-description="Display Name"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" resource-description="Public IP resource name" resource-description-manual="true" target-description="Item Name"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" resource-description="IP Address - supports IPv4 and IPv6 and includes optional netmask data; for example 192 168 22 187/24 or 2001:db8:abcd:0012::/64)" target-description="Public IP"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" resource-description="Public DNS name associated with the IP address" resource-description-manual="true" target-description="Public DNS"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" resource-description="Current state of the public IP address" resource-description-manual="true" target-description="State"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" resource-description="Azure resource URI" resource-description-manual="true" target-description="Resource URI"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" resource-description="IP address version (IPv4 or IPv6)" resource-description-manual="true" target-description="IP Address Version"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" resource-description="IP allocation method (Static or Dynamic)" resource-description-manual="true" target-description="Allocation Method"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" resource-description="TCP idle timeout in minutes" resource-description-manual="true" target-description="Idle Timeout(Minutes)"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" resource-description="Azure SKU name" resource-description-manual="true" target-description="SKU Name"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" resource-description="Azure SKU pricing tier" resource-description-manual="true" target-description="SKU Tier"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+          </mapping>
+      </task>
+
+      <task enable="true" name="D42 Azure Public IP to Freshservice Azure Public IP" type="asset" description="Copy Azure Public IP from Device42 to Freshservice" d42_min_version="19.05.00">
+          <api>
+              <target/>
+              <resource
+                doql="
+                    SELECT
+                      COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))        AS name,
+                      ip.ip_address                                                              AS public_ip,
+                      ip.details ->> 'state'                                                     AS state,
+                      ip.details ->> 'location'                                                  AS region,
+                      ip.details ->> 'guid'                                                      AS item_id,
+                      ip.details ->> 'resource_uri'                                              AS resource_uri,
+                      ip.details ->> 'resource_group'                                            AS resource_group,
+                      ip.details ->> 'provisioning_state'                                        AS provisioning_state,
+                      ip.details ->> 'fqdn'                                                      AS public_dns,
+                      ip.details ->> 'version'                                                   AS version,
+                      ip.details ->> 'allocation_method'                                         AS allocation_method,
+                      ip.details ->> 'idle_timeout'                                              AS idle_timeout,
+                      ip.details ->> 'resource_type'                                             AS resource_type,
+                      ip.details ->> 'sku_name'                                                  AS sku_name,
+                      ip.details ->> 'sku_tier'                                                  AS sku_tier,
+                      infra.account_id                                                           AS account_id,
+                      'AZURE'                                                                    AS provider,
+                      'Azure Public IP Address'                                                  AS asset_type,
+                      format('IP-%s', ip.ipaddress_pk)                                           AS device42_id
+                    FROM
+                      view_ipaddress_v2 ip
+                    JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+                    "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Public IP resource name" resource-description-manual="true" target-description="Display Name"/>
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+              <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+              <!-- Public IP Address -->
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" resource-description="Public IP resource name" resource-description-manual="true" target-description="Item Name"/>
+              <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" resource-description="IP Address - supports IPv4 and IPv6 and includes optional netmask data; for example 192 168 22 187/24 or 2001:db8:abcd:0012::/64)" target-description="Public IP"/>
+              <field resource="public_dns" source-type="string" target="public_dns" target-type="string" target-header="Public IP Address" resource-description="Public DNS name associated with the IP address" resource-description-manual="true" target-description="Public DNS"/>
+              <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" resource-description="Current state of the public IP address" resource-description-manual="true" target-description="State"/>
+              <!-- Azure Public IP Address -->
+              <field resource="resource_uri" source-type="string" target="resource_uri" target-type="sting" target-header="Azure Public IP Address" resource-description="Azure resource URI" resource-description-manual="true" target-description="Resource URI"/>
+              <field resource="resource_group" source-type="string" target="resource_group" target-type="string" target-header="Azure Public IP Address" resource-description="Azure resource group name" resource-description-manual="true" target-description="Resource Group"/>
+              <field resource="provisioning_state" source-type="string" target="cd_provisioning_state" target-type="dropdown" target-header="Azure Public IP Address" resource-description="Azure resource provisioning state" resource-description-manual="true" target-description="Provisioning State"/>
+              <field resource="version" source-type="string" target="ip_address_version" target-type="dropdown" target-header="Azure Public IP Address" resource-description="IP address version (IPv4 or IPv6)" resource-description-manual="true" target-description="IP Address Version"/>
+              <field resource="allocation_method" source-type="string" target="allocation_method" target-type="dropdown" target-header="Azure Public IP Address" resource-description="IP allocation method (Static or Dynamic)" resource-description-manual="true" target-description="Allocation Method"/>
+              <field resource="idle_timeout" source-type="integer" target="idle_timeout_minutes" target-type="integer" target-header="Azure Public IP Address" resource-description="TCP idle timeout in minutes" resource-description-manual="true" target-description="Idle Timeout(Minutes)"/>
+              <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Public IP Address" resource-description="Cloud resource type classification" resource-description-manual="true" target-description="Resource Type"/>
+              <field resource="sku_name" source-type="string" target="cd_sku_name" target-type="dropdown" target-header="Azure Public IP Address" resource-description="Azure SKU name" resource-description-manual="true" target-description="SKU Name"/>
+              <field resource="sku_tier" source-type="string" target="sku_tier" target-type="string" target-header="Azure Public IP Address" resource-description="Azure SKU pricing tier" resource-description-manual="true" target-description="SKU Tier"/>
+              <field resource="account_id" source-type="string" target="subscription_id" target-type="string" target-header="Azure Public IP Address" resource-description="This is the Cloud Account ID - The terms Cloud Infrastructure and Cloud Account are used interchangeably" target-description="Subscription ID"/>
+          </mapping>
+      </task>
+
+       <!-- GCP Image -->
+        <task enable="true" name="D42 GCP Image to Freshservice GCP Image" type="asset" description="Copy GCP Image from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              resource.details ->> 'description'                                         AS description,
+              resource.details ->> 'guest_os'                                            AS guest_os,
+              resource.details ->> 'kind'                                                AS kind,
+              resource.details ->> 'status'                                              AS status,
+              resource.details ->> 'self_link'                                           AS self_link,
+              resource.details ->> 'source_id'                                           AS source_id,
+              resource.details ->> 'image_source'                                        AS image_source,
+              resource.details ->> 'disk_size_gb'                                        AS disk_size_gb,
+              resource.details ->> 'storage_location'                                    AS storage_location,
+              (resource.details ->> 'creation_timestamp')::timestamptz                   AS creation_timestamp,
+              'global'                                                                   AS region,
+              'GCP'                                                                      AS provider,
+              'GCP Image'                                                                AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['GCP Image']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- GCP Image -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="GCP machine image name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Image" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Image" min-length="1" max-length="248" escape="true" resource-description="GCP machine image name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="image_source" source-type="string" target="image_source" target-type="string" target-header="Image" resource-description="Source of the image" resource-description-manual="true" target-description="Image Source"/>
+            <field resource="guest_os" source-type="string" target="guest_os" target-type="dropdown" target-header="Image" resource-description="Guest operating system name" resource-description-manual="true" target-description="Guest OS"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Image" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="status" source-type="string" target="status" target-type="dropdown" target-header="GCP Image" resource-description="Current resource status" resource-description-manual="true" target-description="Status"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Image" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+            <field resource="source_id" source-type="string" target="source_id" target-type="string" target-header="GCP Image" resource-description="Source resource identifier for the image" resource-description-manual="true" target-description="Source ID"/>
+            <field resource="kind" source-type="string" target="kind" target-type="string" target-header="GCP Image" resource-description="GCP resource kind identifier" resource-description-manual="true" target-description="Kind"/>
+            <field resource="disk_size_gb" source-type="string" target="disk_size" target-type="integer" target-header="GCP Image" resource-description="Disk size of the image in GB" resource-description-manual="true" target-description="Disk Size (GB)"/>
+            <field resource="storage_location" source-type="string" target="storage_location" target-type="string" target-header="GCP Image" resource-description="Cloud Storage location where the image is stored" resource-description-manual="true" target-description="Storage Location"/>
+         </mapping>
+       </task>
+
+        <!-- GCP BigQuery Table -->
+        <task enable="true" name="D42 GCP BigQuery Table to Freshservice GCP BigQuery Table" type="asset" description="Copy GCP BigQuery Table from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                        AS name,
+              resource.identifier                           AS item_id,
+              'global'                                      AS region,
+              resource.details ->> 'table_id'               AS table_id,
+              resource.details ->> 'item_id'                AS item_id,
+              (resource.details ->> 'creation_timestamp')::timestamptz AS creation_timestamp,
+              (resource.details ->> 'expiration_timestamp')::timestamptz AS expiration_timestamp,
+              resource.details ->> 'type'                   AS type,
+              resource.details ->> 'friendly_name'          AS friendly_name,
+              false::boolean                                AS multiple_availability_zone,
+              'GCP'                                         AS provider,
+              'GCP BigQuery Table'                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)   AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE
+              'gcp_bigquery_table' = ANY(resource.category)
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="GCP BigQuery table name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Database" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="table_id" source-type="string" target="item_name" target-type="string" target-header="Database" min-length="1" max-length="255" resource-description="BigQuery table identifier" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="multiple_availability_zone" source-type="boolean" target="multiple_availability_zone" target-type="boolean" target-header="Database" resource-description="Whether multi-zone replication is enabled" resource-description-manual="true" target-description="Multiple Availability Zone"/>
+            <field resource="friendly_name" source-type="string" target="friendly_name" target-type="string" target-header="GCP BigQuery Table" min-length="1" max-length="255" resource-description="User-friendly display name for the BigQuery table" resource-description-manual="true" target-description="Friendly Name"/>
+            <field resource="type" source-type="string" target="type" target-type="dropdown" target-header="GCP BigQuery Table" resource-description="Resource type classification" resource-description-manual="true" target-description="Type"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP BigQuery Table" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="expiration_timestamp" source-type="datetime" target="expiration_timestamp" target-type="datetime" target-header="GCP BigQuery Table" resource-description="Date and time when the resource expires and is auto-deleted" resource-description-manual="true" target-description="Expiration Timestamp"/>
+          </mapping>
+        </task>
+        <!-- ~GCP BigQuery Table -->
+
+       <!-- Azure Key Vault -->
+        <task enable="true" name="D42 Azure Key Vault to Freshservice Azure Key Vault" type="asset" description="Copy Azure Key Vault from Device42 to Freshservice" d42_min_version="19.04.00">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              CONCAT(resource.details ->> 'subscription_id', '/', resource.details ->> 'resource_group', '/', resource.resource_name) AS item_id,
+              resource.vendor_resource_subtype                                           AS resource_type,
+              resource.region                                                            AS region,
+              'AZURE'                                                                    AS provider,
+              'Azure Key Vault'                                                          AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            WHERE resource.category @> ARRAY['azureKeyVault']
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- Azure Key Vault -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Azure Key Vault name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Key Vault" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Key Vault" min-length="1" max-length="248" escape="true" resource-description="Azure Key Vault name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="resource_type" source-type="string" target="resource_type" target-type="string" target-header="Azure Key Vault" resource-description="Subtype of Resource such as aurora, mysql, etc" target-description="Resource Type"/>
+         </mapping>
+       </task>
+
+        <!-- VMware VCenter Resource Pool -->
+        <task enable="true" name="D42 VMware VCenter Resource Pool to Freshservice VMware VCenter Resource Pool" type="asset" description="Copy VMware VCenter Resource Pool from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                      AS name,
+                resource.identifier                                                                         AS item_id,
+                resource.details ->> 'overall_status'                                                       AS overall_state,
+                round((resource.details ->> 'cpu_max_usage')::numeric, 2)::text                             AS cpu_max_usage,
+                round((resource.details ->> 'cpu_reservation_used')::numeric, 2)::text                      AS cpu_reservation_used,
+                round(((resource.details ->> 'memory_max_usage')::float / 1024.0)::numeric, 2)::text        AS memory_max_usage,
+                round(((resource.details ->> 'memory_reservation_used')::float / 1024.0)::numeric, 2)::text AS memory_reservation_used,
+                resource.details ->> 'vm_manager_ref_id'                                                    AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                            AS provider,
+                'VMware VCenter Resource Pool'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                 AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Resource Pool'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="VMware vCenter resource pool name" resource-description-manual="true" target-description="Display Name"/>
+
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Resource Pool" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Resource Pool" resource-description="VMware vCenter resource pool name" resource-description-manual="true" target-description="Item Name"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Resource Pool" resource-description="Overall health state of the VMware resource" resource-description-manual="true" target-description="State"/>
+
+                <field resource="cpu_max_usage" source-type="string" target="cpu_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" resource-description="Maximum CPU usage allowed (MHz)" resource-description-manual="true" target-description="CPU Max Usage(GHz)"/>
+                <field resource="cpu_reservation_used" source-type="string" target="cpu_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" resource-description="CPU reservation currently consumed (MHz)" resource-description-manual="true" target-description="CPU Reservation Used(GHz)"/>
+                <field resource="memory_max_usage" source-type="string" target="memory_max_usage" target-type="string" target-header="VMware VCenter Resource Pool" resource-description="Maximum memory usage allowed (MB)" resource-description-manual="true" target-description="Memory Max Usage(GB)"/>
+                <field resource="memory_reservation_used" source-type="string" target="memory_reservation_used" target-type="string" target-header="VMware VCenter Resource Pool" resource-description="Memory reservation currently consumed (MB)" resource-description-manual="true" target-description="Memory Reservation Used(GB)"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Resource Pool" resource-description="VMware vCenter managed object reference ID (MOID)" resource-description-manual="true" target-description="MoRef ID"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Network -->
+        <task enable="true" name="D42 VMware VCenter Network to Freshservice VMware VCenter Network" type="asset" description="Copy VMware VCenter Network from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                              AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'vm_manager_ref_id') AS item_id,
+                resource.details ->> 'overall_status'                                                               AS overall_state,
+                (resource.details ->> 'accessible')::boolean                                                        AS connection_state,
+                resource.details ->> 'hosts_count'                                                                  AS hosts,
+                resource.details ->> 'vms_count'                                                                    AS vms,
+                resource.details ->> 'ip_pool_id'                                                                   AS ip_pool_id,
+                resource.details ->> 'ip_pool_name'                                                                 AS ip_pool_name,
+                resource.details ->> 'vm_manager_ref_id'                                                                AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                                    AS provider,
+                'VMware VCenter Network'                                                                            AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                                         AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Network'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="VMware vCenter network name" resource-description-manual="true" target-description="Display Name"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Network" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Network" resource-description="VMware vCenter network name" resource-description-manual="true" target-description="Item Name"/>
+              <field resource="overall_state" source-type="string" target="state" target-type="string" target-header="Network" resource-description="Overall health state of the VMware resource" resource-description-manual="true" target-description="State"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Network" resource-description="Network connection state" resource-description-manual="true" target-description="Connection State">
+                  <value-mapping default="Not Responding">
+                    <item key="true" value="Connected"/>
+                  </value-mapping>
+                </field>
+
+              <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Network" resource-description="Comma-separated list of hosts in the resource" resource-description-manual="true" target-description="Hosts"/>
+              <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Network" resource-description="Comma-separated list of virtual machines in the resource" resource-description-manual="true" target-description="Virtual Machines"/>
+              <field resource="ip_pool_id" source-type="string" target="ip_pool_id" target-type="string" target-header="VMware VCenter Network" resource-description="IP address pool identifier" resource-description-manual="true" target-description="IP Pool Id"/>
+              <field resource="ip_pool_name" source-type="string" target="ip_pool_name" target-type="string" target-header="VMware VCenter Network" resource-description="IP address pool name" resource-description-manual="true" target-description="IP Pool Name"/>
+              <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Network" resource-description="VMware vCenter managed object reference ID (MOID)" resource-description-manual="true" target-description="MoRef ID"/>
+            </mapping>
+       </task>
+
+       <!-- VMware VCenter Disk -->
+       <task enable="true" name="D42 VMware VCenter Disk to Freshservice VMware VCenter Disk" type="asset" description="Copy VMware VCenter Disk from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+              <target/>
+              <resource
+              doql="
+              with device_cluster AS (
+                SELECT device_cluster.child_device_fk device_fk,
+                string_agg(device_cluster.parent_device_name, ', ' order by device_cluster.parent_device_name) as device_cluster_name
+                FROM view_devices_in_cluster_v1 device_cluster group by device_cluster.child_device_fk)
+              SELECT
+                resource.details ->> 'file_name'                                                   AS name,
+                resource.identifier                                                                AS item_id,
+                round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 0)::text AS storage_usable,
+                (resource.details ->> 'key')::integer                                              AS key,
+                (resource.details ->> 'unit_number')::integer                                      AS unit_number,
+                resource.details ->> 'vdisk_id'                                                    AS vdisk_id, 
+                virtual_host_device.datacenter                                                     AS host_datacenter,
+                host_device_cluster.device_cluster_name                                            AS host_cluster_name,
+                'Available'                                                                        AS state,
+                'VMWARE VCENTER'                                                                   AS provider,
+                'VMware VCenter Disk'                                                              AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                        AS device42_id
+              FROM
+                view_resource_v2 resource
+                LEFT JOIN view_deviceresource_v1 as resource_device ON resource.resource_pk = resource_device.resource_fk
+                LEFT JOIN view_device_v2 as device ON resource_device.device_fk = device.device_pk
+                LEFT JOIN view_device_v2 as virtual_host_device ON device.virtual_host_device_fk = virtual_host_device.device_pk
+                LEFT JOIN device_cluster as host_device_cluster ON virtual_host_device.device_pk = host_device_cluster.device_fk
+              WHERE resource.category @> ARRAY['vmware', 'vdisk', 'vcenter'] AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+              <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+              <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Virtual disk file name" resource-description-manual="true" target-description="Display Name"/>
+              <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+              <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Volume" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+              <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Volume" resource-description="Virtual disk file name" resource-description-manual="true" target-description="Item Name"/>
+              <field resource="storage_usable" source-type="string" target="cd_volume_size" target-type="string" target-header="Volume" resource-description="Virtual disk capacity in GB" resource-description-manual="true" target-description="Size(GB)"/>
+              <field resource="state" source-type="string" target="cd_volume_state" target-type="dropdown" target-header="Volume" resource-description="Virtual disk state" resource-description-manual="true" target-description="State"/>
+              <field resource="host_datacenter" source-type="string" target="datacenter" target-type="string" target-header="VMware VCenter Disk" resource-description="The Datacenter where the device resides - It must be assigned, it is not discovered" target-description="Datacenter"/>
+              <field resource="host_cluster_name" source-type="string" target="cluster" target-type="string" target-header="VMware VCenter Disk" resource-description="VMware cluster the VM is running on" resource-description-manual="true" target-description="Cluster"/>
+              <field resource="name" source-type="string" target="file_name" target-type="string" target-header="VMware VCenter Disk" resource-description="Virtual disk file name" resource-description-manual="true" target-description="File Name"/>
+              <field resource="vdisk_id" source-type="string" target="vdisk_id" target-type="string" target-header="VMware VCenter Disk" resource-description="Virtual disk identifier" resource-description-manual="true" target-description="vDiskId"/>
+              <field resource="key" source-type="integer" target="key" target-type="integer" target-header="VMware VCenter Disk" resource-description="Virtual disk key identifier within the VM configuration" resource-description-manual="true" target-description="Key"/>
+              <field resource="unit_number" source-type="integer" target="unit_number" target-type="integer" target-header="VMware VCenter Disk" resource-description="SCSI unit number of the virtual disk" resource-description-manual="true" target-description="Unit Number"/>
+          </mapping>
+        </task>
+
+        <!-- VMware VCenter Datastore -->
+        <task enable="true" name="D42 VMware VCenter Datastore to Freshservice VMware VCenter Datastore" type="asset" description="Copy VMware VCenter Datastore from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+                <target/>
+                <resource
+                doql="
+                SELECT
+                  resource.resource_name                                                                                                        AS name,
+                  concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.details ->> 'datastore_url')                           AS item_id,
+                  round(((resource.details ->> 'storage_usable')::float / 1024.0)::numeric, 2)                                                  AS storage_usable,
+                  round((((resource.details ->> 'storage_usable')::float - (resource.details ->> 'storage_used')::float) / 1024.0)::numeric, 2) AS free_space,
+                  resource.details ->> 'overall_status'                                                                                         AS overall_state,
+                  (resource.details ->> 'hosts_count')::integer                                                                                 AS hosts,
+                  (resource.details ->> 'vms_count')::integer                                                                                   AS vms,
+                  resource.details ->> 'storage_type'                                                                                           AS storage_type,
+                  resource.details ->> 'datastore_url'                                                                                          AS datastore_url,
+                  (resource.details ->> 'max_virtual_disk_capacity')::float / 1024.0 / 1024.0 / 1024.0                                          AS max_virtual_disk_capacity,
+                  (resource.details ->> 'multiple_host_access')::boolean                                                                        AS multiple_host_access,
+                  CASE
+                    WHEN (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0 > 99999999.99 THEN 99999999.99
+                    ELSE (resource.details ->> 'max_memory_file_size')::float / 1024.0 / 1024.0 / 1024.0
+                  END                                                                                                                           AS max_memory_file_size,
+                  (resource.details ->> 'max_file_size')::float / 1024.0 / 1024.0 / 1024.0                                                      AS max_file_size,
+                  resource.details ->> 'container_id'                                                                                           AS container_id,
+                  resource.details ->> 'vm_manager_ref_id'                                                                                      AS vcenter_ref_id,
+                  (resource.details ->> 'accessible')::boolean                                                                                  AS connection_state,
+                  'VMWARE VCENTER'                                                                                                              AS provider,
+                  'VMware VCenter Datastore'                                                                                                    AS asset_type,
+                  format('Resource-%s', resource.resource_pk)                                                                                   AS device42_id
+                FROM
+                  view_resource_v2 resource
+                WHERE 'vcenter' = ANY(resource.category) AND 'ds' = ANY(resource.category) AND resource.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="VMware vCenter datastore name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datastore" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datastore" resource-description="VMware vCenter datastore name" resource-description-manual="true" target-description="Item Name"/>
+                <field resource="storage_usable" source-type="float" target="capacity" target-type="float" target-header="Datastore" resource-description="Total usable capacity of the datastore" resource-description-manual="true" target-description="Size(GB)"/>
+                <field resource="connection_state" source-type="boolean" target="connection_state" target-type="string" target-header="Datastore" resource-description="Connection state (connected, disconnected, etc.)" resource-description-manual="true" target-description="Connection State">
+                    <value-mapping default="Not Responding">
+                        <item key="true" value="Connected"/>
+                    </value-mapping>
+                </field>
+                <field resource="free_space" source-type="float" target="free_space" target-type="float" target-header="Datastore" resource-description="Available free space on the datastore" resource-description-manual="true" target-description="Free Space(GB)"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datastore" resource-description="Overall health state of the VMware resource" resource-description-manual="true" target-description="State"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datastore" resource-description="Comma-separated list of hosts in the resource" resource-description-manual="true" target-description="Hosts"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datastore" resource-description="Comma-separated list of virtual machines in the resource" resource-description-manual="true" target-description="Virtual Machines"/>
+                <field resource="storage_type" source-type="string" target="datastore_type" target-type="dropdown" target-header="VMware VCenter Datastore" resource-description="Datastore type (VMFS, NFS, vSAN, etc.)" resource-description-manual="true" target-description="Type"/>
+                <field resource="datastore_url" source-type="string" target="url" target-type="string" target-header="VMware VCenter Datastore" resource-description="Datastore URL path" resource-description-manual="true" target-description="Url"/>
+                <field resource="max_virtual_disk_capacity" source-type="float" target="max_virtual_disk_capacity" target-type="float" target-header="VMware VCenter Datastore" resource-description="Maximum virtual disk capacity on the datastore" resource-description-manual="true" target-description="Max Virtual Disk Capacity(GB)"/>
+                <field resource="multiple_host_access" source-type="boolean" target="multiple_host_access" target-type="boolean" target-header="VMware VCenter Datastore" resource-description="Whether multiple hosts can access the datastore concurrently" resource-description-manual="true" target-description="Multiple Host Access"/>
+                <field resource="max_memory_file_size" source-type="float" target="max_memory_file_size" target-type="float" target-header="VMware VCenter Datastore" resource-description="Maximum memory file size supported" resource-description-manual="true" target-description="Max Memory File Size(GB)"/>
+                <field resource="max_file_size" source-type="float" target="max_file_size" target-type="float" target-header="VMware VCenter Datastore" resource-description="Maximum supported file size on the datastore" resource-description-manual="true" target-description="Max File Size(GB)"/>
+                <field resource="container_id" source-type="string" target="container_id" target-type="string" target-header="VMware VCenter Datastore" resource-description="VMware container identifier for the datastore" resource-description-manual="true" target-description="Container ID"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datastore" resource-description="VMware vCenter managed object reference ID (MOID)" resource-description-manual="true" target-description="MoRef ID"/>
+            </mapping>
+        </task>
+
+        <!-- VMware VCenter Datacenter -->
+        <task enable="true" name="D42 VMware VCenter Datacenter to Freshservice VMware VCenter Datacenter" type="asset" description="Copy VMware VCenter Datacenter from Device42 to Freshservice" d42_min_version="19.04.10">
+            <api>
+              <target/>
+              <resource
+              doql="
+              SELECT
+                resource.resource_name                                                                AS name,
+                concat_ws('_', resource.details ->> 'vm_manager_instance_id', resource.resource_name) AS item_id,
+                resource.details ->> 'overall_status'                                                 AS overall_state,
+                resource.details ->> 'hosts_count'                                                    AS hosts,
+                resource.details ->> 'vms_count'                                                      AS vms,
+                resource.details ->> 'networks_count'                                                 AS networks,
+                resource.details ->> 'clusters_count'                                                 AS clusters,
+                resource.details ->> 'datastores_count'                                               AS datastores,
+                resource.details ->> 'datastore_folder'                                               AS datastore_folder,
+                resource.details ->> 'host_folder'                                                    AS host_folder,
+                resource.details ->> 'network_folder'                                                 AS network_folder,
+                resource.details ->> 'vm_folder'                                                      AS vm_folder,
+                round((resource.details ->> 'cpu_capacity')::numeric, 2)                              AS total_cpu,
+                round(((resource.details ->> 'memory')::float / 1024.0)::numeric, 2)                  AS total_memory,
+                0.0                                                                                   AS total_storage,
+                resource.details ->> 'vm_manager_ref_id'                                              AS vcenter_ref_id,
+                'VMWARE VCENTER'                                                                      AS provider,
+                'VMware VCenter Datacenter'                                                           AS asset_type,
+                format('Resource-%s', resource.resource_pk)                                           AS device42_id
+              FROM
+                view_resource_v2 resource
+              WHERE 'vcenter' = ANY(resource.category) AND resource.vendor_resource_type = 'Datacenter'
+              "
+              />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id" item-id="item_id"/>
+            </matching>
+            <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+                <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+                <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="VMware resource name" resource-description-manual="true" target-description="Display Name"/>
+                <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+                <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Datacenter" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+                <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Datacenter" resource-description="VMware resource name" resource-description-manual="true" target-description="Item Name"/>
+                <field resource="overall_state" source-type="string" target="state" target-type="dropdown" target-header="Datacenter" resource-description="Overall health state of the VMware resource" resource-description-manual="true" target-description="State"/>
+                <field resource="hosts" source-type="integer" target="hosts" target-type="integer" target-header="VMware VCenter Datacenter" resource-description="Comma-separated list of hosts in the resource" resource-description-manual="true" target-description="Hosts"/>
+                <field resource="vms" source-type="integer" target="virtual_machines" target-type="integer" target-header="VMware VCenter Datacenter" resource-description="Comma-separated list of virtual machines in the resource" resource-description-manual="true" target-description="Virtual Machines"/>
+                <field resource="networks" source-type="integer" target="networks" target-type="integer" target-header="VMware VCenter Datacenter" resource-description="Comma-separated list of networks in the resource" resource-description-manual="true" target-description="Networks"/>
+                <field resource="clusters" source-type="integer" target="clusters" target-type="integer" target-header="VMware VCenter Datacenter" resource-description="Comma-separated list of clusters in the datacenter" resource-description-manual="true" target-description="Clusters"/>
+
+                <field resource="datastores" source-type="integer" target="datastores" target-type="integer" target-header="VMware VCenter Datacenter" resource-description="Comma-separated list of datastores in the datacenter" resource-description-manual="true" target-description="Datastores"/>
+                <field resource="datastore_folder" source-type="string" target="datastore_folder" target-type="string" target-header="VMware VCenter Datacenter" resource-description="Datastore folder path in the datacenter inventory" resource-description-manual="true" target-description="Datastore Folder"/>
+
+                <field resource="host_folder" source-type="string" target="host_folder" target-type="string" target-header="VMware VCenter Datacenter" resource-description="Host folder path in the datacenter inventory" resource-description-manual="true" target-description="Host Folder"/>
+                <field resource="network_folder" source-type="string" target="network_folder" target-type="string" target-header="VMware VCenter Datacenter" resource-description="Network folder path in the datacenter inventory" resource-description-manual="true" target-description="Network Folder"/>
+                <field resource="vm_folder" source-type="string" target="virtual_machine_folder" target-type="string" target-header="VMware VCenter Datacenter" resource-description="Virtual machine folder path in the datacenter inventory" resource-description-manual="true" target-description="Virtual Machine Folder"/>
+                <field resource="total_cpu" source-type="float" target="total_cpu" target-type="float" target-header="VMware VCenter Datacenter" resource-description="Total CPU capacity across all hosts (MHz)" resource-description-manual="true" target-description="Total CPU(GHz)"/>
+                <field resource="total_memory" source-type="float" target="total_memory" target-type="float" target-header="VMware VCenter Datacenter" resource-description="Total memory capacity across all hosts (MB)" resource-description-manual="true" target-description="Total Memory(GB)"/>
+                <field resource="total_storage" source-type="float" target="total_storage" target-type="float" target-header="VMware VCenter Datacenter" resource-description="Total storage capacity across all datastores (GB)" resource-description-manual="true" target-description="Total Storage(GB)"/>
+                <field resource="vcenter_ref_id" source-type="string" target="moid" target-type="string" target-header="VMware VCenter Datacenter" resource-description="VMware vCenter managed object reference ID (MOID)" resource-description-manual="true" target-description="MoRef ID"/>
+            </mapping>
+        </task>
+
+               <!-- AWS K8 Pod -->
+        <task enable="true" name="D42 AWS K8 Pod to Freshservice AWS K8 Pod" type="asset" description="Copy AWS K8 Pod from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'generate_name'                                       AS generate_name,
+              resource.details ->> 'status'                                              AS phase,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Pod'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['pod', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <!-- K8s Pod -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Pod" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Pod" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Pod" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Pod" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Pod" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <!-- AWS K8s Pod -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Pod" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Pod" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="generate_name" source-type="string" target="generate_name" target-type="string" target-header="AWS K8s Pod" resource-description="Kubernetes generateName prefix used for pod naming" resource-description-manual="true" target-description="Generate Name"/>
+            <field resource="phase" source-type="string" target="phase" target-type="string" target-header="AWS K8s Pod" resource-description="Pod lifecycle phase (Pending, Running, Succeeded, Failed)" resource-description-manual="true" target-description="Phase"/>
+         </mapping>
+       </task>
+
+        <task enable="true" name="D42 K8s Namespace to Freshservice AWS K8s Namespace" type="asset" description="Copy AWS K8s Namespace from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Namespace'                    AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['namespace', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <!-- K8s Namespace -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Namespace" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Namespace" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Namespace" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Namespace" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Namespace" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <!-- AWS K8s Namespace -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Namespace" min-length="1" max-length="255" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Deployment to Freshservice AWS K8s Deployment" type="asset" description="Copy AWS K8s Deployment from Device42 to Deployment" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                           AS name,
+                     r.identifier                              AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                       AS region,
+                     CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                       AS availability_zone,
+                     c.resource_name                           AS cluster_name, 
+                     c.details->>'endpoint'                    AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz  AS creation_timestamp, 
+                     r.details->>'resource_version'            AS resource_version,
+                     r.details->>'replicas'                    AS replicas,
+                     r.details->>'available_replicas'          AS available_replicas,
+                     r.details->>'ready_replicas'              AS ready_replicas,
+                     r.details->>'updated_replicas'            AS updated_replicas,
+                     r.details->>'namespace'                   AS namespace,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     'AWS'                                     AS provider,
+                     'AWS K8s Deployment'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)      AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['deployment', 'Kubernetes'] and v.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <!-- K8s Deployment -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Deployment" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Deployment" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Deployment" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Deployment" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Deployment" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <!-- AWS K8s Deployment -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Deployment" resource-description="Kubernetes resource generation number" resource-description-manual="true" target-description="Generation"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255" resource-description="Desired number of pod replicas" resource-description-manual="true" target-description="Replicas"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255" resource-description="Number of pods that are available and ready to serve" resource-description-manual="true" target-description="Available Replicas"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255" resource-description="Number of pods in the ready condition" resource-description-manual="true" target-description="Ready Replicas"/>
+            <field resource="updated_replicas" source-type="string" target="updated_replicas" target-type="string" target-header="AWS K8s Deployment" min-length="1" max-length="255" resource-description="Number of pods updated to the desired template" resource-description-manual="true" target-description="Updated Replicas"/>
+          </mapping>
+        </task>
+        <task enable="true" name="D42 K8s Service to Freshservice AWS K8s Service" type="asset" description="Copy AWS K8s Service from Device42 to Service" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'cluster_ip'               AS cluster_ip,
+                     r.details->>'type'                     AS service_type,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Service'                      AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['service', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <!-- K8s Service -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Service" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Service" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Service" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Service" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Service" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <!-- AWS K8s Service -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+            <field resource="service_type" source-type="string" target="service_type" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255" resource-description="Service type (ClusterIP, NodePort, LoadBalancer, ExternalName)" resource-description-manual="true" target-description="Service Type"/>
+            <field resource="cluster_ip" source-type="string" target="cluster_ip" target-type="string" target-header="AWS K8s Service" min-length="1" max-length="255" resource-description="Kubernetes cluster-internal IP address for the service" resource-description-manual="true" target-description="Cluster IP"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Daemon Set to Freshservice AWS K8s Daemon Set" type="asset" description="Copy AWS K8s Daemon Set from Device42 to Daemon Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Daemon Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['daemon_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <!-- K8s Daemon Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Daemon Set" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Daemon Set" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Daemon Set" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Daemon Set" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Daemon Set" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <!-- AWS K8s Daemon Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Daemon Set" min-length="1" max-length="255" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+            <field resource="generation" source-type="integer" target="generation" target-type="integer" target-header="AWS K8s Daemon Set" resource-description="Kubernetes resource generation number" resource-description-manual="true" target-description="Generation"/>
+          </mapping>
+        </task>
+
+        <!-- AWS K8s Replica Set -->
+       <task enable="true" name="D42 AWS K8s Replica Set to Freshservice AWS K8s Replica Set" type="asset" description="Copy AWS K8s Replica Set from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.details ->> 'replicas'                                            AS replicas,
+              resource.details ->> 'ready_replicas'                                      AS ready_replicas,
+              resource.details ->> 'available_replicas'                                  AS available_replicas,
+              resource.details ->> 'fully_labeled_replicas'                              AS fully_labeled_replicas,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Replica Set'                                                      AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['replica_set', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <!-- K8s Replica Set -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Replica Set" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Replica Set" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Replica Set" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Replica Set" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Replica Set" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <!-- AWS K8s Replica Set -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Replica Set" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Replica Set" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="replicas" source-type="string" target="replicas" target-type="string" target-header="AWS K8s Replica Set" resource-description="Desired number of pod replicas" resource-description-manual="true" target-description="Replicas"/>
+            <field resource="available_replicas" source-type="string" target="available_replicas" target-type="string" target-header="AWS K8s Replica Set" resource-description="Number of pods that are available and ready to serve" resource-description-manual="true" target-description="Available Replicas"/>
+            <field resource="fully_labeled_replicas" source-type="string" target="fully_labeled_replicas" target-type="string" target-header="AWS K8s Replica Set" resource-description="Number of pods with all required labels applied" resource-description-manual="true" target-description="Fully Labeled Replicas"/>
+            <field resource="ready_replicas" source-type="string" target="ready_replicas" target-type="string" target-header="AWS K8s Replica Set" resource-description="Number of pods in the ready condition" resource-description-manual="true" target-description="Ready Replicas"/>
+         </mapping>
+       </task>
+
+       <!-- AWS K8s Cron Job -->
+       <task enable="true" name="D42 AWS K8s Cron Job to Freshservice AWS K8s Cron Job" type="asset" description="Copy AWS K8s Cron Job from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              resource.resource_name                                                     AS name,
+              resource.identifier                                                        AS item_id,
+              cluster.resource_name                                                      AS cluster_name,
+              cluster.details ->> 'endpoint'                                             AS cluster_url,
+              cluster.details ->> 'selector'                                             AS selector,
+              (resource.details ->> 'create_time')::timestamptz                          AS creation_timestamp,
+              resource.details ->> 'namespace'                                           AS namespace,
+              resource.details ->> 'resource_version'                                    AS resource_version,
+              resource.region                                                            AS region,
+              'AWS'                                                                      AS provider,
+              'AWS K8s Cron Job'                                                              AS asset_type,
+              format('Resource-%s', resource.resource_pk)                                AS device42_id
+            FROM
+              view_resource_v2 resource
+            JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            LEFT JOIN view_resource_v2 cluster ON resource.root_resource_fk = cluster.resource_pk
+            WHERE resource.category @> ARRAY['cron_job', 'Kubernetes'] AND vendor.name = 'Amazon'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND resource.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" resource-description="An array of one or more Regions for Resource such as eu-west-1,us-east1, us-west-2, etc  " target-description="Region"/>
+            <!-- K8s Cron Job -->
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Cron Job" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Cron Job" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Cron Job" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Cron Job" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Cron Job" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <!-- AWS K8s Cron Job -->
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Cron Job" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Cron Job" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+         </mapping>
+       </task>
+
+       <task enable="true" name="D42 GCP Public IP to Freshservice GCP Public IP" type="asset" description="Copy GCP Public IP from Device42 to Freshservice" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+            SELECT
+              ip.details ->> 'id'                                           AS item_id,
+              ip.details ->> 'name'                                         AS name,
+              ip.ip_address                                                 AS public_ip,
+              CASE
+                WHEN ip.details ->> 'state' = 'IN_USE' THEN 'Attached'
+                ELSE 'Unattached'
+              END                                                           AS state,
+              (ip.details ->> 'creation_timestamp')::timestamptz            AS creation_timestamp,
+              ip.details ->> 'self_link'                                    AS self_link,
+              ip.details ->> 'network_tier'                                 AS network_tier,
+              ip.details ->> 'address_type'                                 AS address_type,
+              ip.details ->> 'description'                                  AS description,
+              ip.details ->> 'region'                                       AS region,
+              'GCP'                                                         AS provider,
+              'GCP Public IP Address'                                       AS asset_type,
+              format('ip-%s', ip.ipaddress_pk)                              AS device42_id
+            FROM
+              view_ipaddress_v2 ip
+            JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+            JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+            WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Google'
+            "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND ip.last_changed > '%s'">
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="Public IP resource name" resource-description-manual="true" target-description="Display Name"/>
+
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="Public IP Address" error-skip="true" resource-description="Cloud provider resource identifier" resource-description-manual="true" target-description="Item ID"/>
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="Public IP Address" resource-description="Public IP resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="public_ip" source-type="string" target="public_ip" target-type="string" target-header="Public IP Address" resource-description="IP Address - supports IPv4 and IPv6 and includes optional netmask data; for example 192 168 22 187/24 or 2001:db8:abcd:0012::/64)" target-description="Public IP"/>
+            <field resource="state" source-type="string" target="state" target-type="dropdown" target-header="Public IP Address" resource-description="Current state of the public IP address" resource-description-manual="true" target-description="State"/>
+
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="GCP Public IP Address" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+            <field resource="self_link" source-type="string" target="self_link" target-type="string" target-header="GCP Public IP Address" resource-description="GCP resource self-link URL" resource-description-manual="true" target-description="Self Link"/>
+            <field resource="network_tier" source-type="string" target="network_tier" target-type="dropdown" target-header="GCP Public IP Address" resource-description="Network service tier (PREMIUM or STANDARD)" resource-description-manual="true" target-description="Network Tier"/>
+            <field resource="address_type" source-type="string" target="address_type" target-type="dropdown" target-header="GCP Public IP Address" resource-description="IP address type (EXTERNAL or INTERNAL)" resource-description-manual="true" target-description="Address Type"/>
+            <field resource="description" source-type="string" target="description" target-type="string" target-header="GCP Public IP Address" resource-description="User-provided description of the public IP" resource-description-manual="true" target-description="Description"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Config Map to Freshservice AWS K8s Config Map" type="asset" description="Copy AWS K8s Config Map from Device42 to Config Map" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     (r.details->>'observed_generation')::INTEGER  AS generation,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Config Map'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['config_map', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <!-- K8s Config Map -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Config Map" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Config Map" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Config Map" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Config Map" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Config Map" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <!-- AWS K8s Config Map -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Config Map" min-length="1" max-length="255" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+          </mapping>
+        </task>
+
+        <task enable="true" name="D42 K8s Stateful Set to Freshservice AWS K8s Stateful Set" type="asset" description="Copy AWS K8s Stateful Set from Device42 to Stateful Set" d42_min_version="19.04.10">
+          <api>
+            <target/>
+            <resource
+            doql="
+              SELECT
+                     r.resource_name                        AS name,
+                     r.identifier                           AS item_id,
+                     CASE
+                     WHEN r.region LIKE '%,%' THEN ''
+                     ELSE r.region
+                     END                                    AS region,
+                    CASE
+                            WHEN array_to_string(r.zones, ',', '*') ILIKE '%,%' THEN ''
+                            ELSE array_to_string(r.zones, ',', '*')
+                     END                                    AS availability_zone,
+                     c.resource_name                        AS cluster_name, 
+                     c.details->>'endpoint'                 AS cluster_url, 
+                     (r.details->>'create_time')::timestamptz AS creation_timestamp, 
+                     r.details->>'resource_version'         AS resource_version,
+                     r.details->>'namespace'                AS namespace,
+                     'AWS'                                  AS provider,
+                     'AWS K8s Stateful Set'                   AS asset_type,
+                     format('Resource-%s', r.resource_pk)   AS device42_id
+              FROM
+                     view_resource_v2 r 
+                     inner join view_resource_v2 c on r.root_resource_fk = c.resource_pk 
+                     inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                     inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+              WHERE
+                     r.category @> ARRAY['stateful_set', 'Kubernetes'] and v.name = 'Amazon'
+              "
+            />
+          </api>
+          <matching>
+              <source-1 device42-id="device42_id" item-id="item_id"/>
+          </matching>
+          <mapping key="name" doql-suffix=" AND r.last_changed > '%s'">
+            <!-- General -->
+            <field resource="device42_id" source-type="string" target="device42_id" target-type="string" target-header="General" resource-description="Unique Device42 identifier for this asset" resource-description-manual="true" target-description="Device42 ID"/>
+            <field resource="name" source-type="string" target="name" target-type="string" target-header="General" min-length="1" max-length="248" escape="true" resource-description="AWS resource name" resource-description-manual="true" target-description="Display Name"/>
+            <!-- Cloud -->
+            <field resource="provider" source-type="string" target="provider_type" target-type="dropdown" target-header="Cloud" resource-description="Cloud service provider (AWS, Azure, GCP, etc.)" resource-description-manual="true" target-description="Provider"/>
+            <field resource="region" source-type="string" target="region" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Cloud region where the resource is deployed" resource-description-manual="true" target-description="Region"/>
+            <field resource="availability_zone" source-type="string" target="cd_availability_zone" target-type="dropdown" target-header="Cloud" min-length="1" max-length="255" resource-description="Availability zone within the cloud region" resource-description-manual="true" target-description="Availability Zone"/>
+            <!-- K8s Stateful Set -->
+            <field resource="name" source-type="string" target="item_name" target-type="string" target-header="K8s Stateful Set" resource-description="AWS resource name" resource-description-manual="true" target-description="Item Name"/>
+            <field resource="item_id" source-type="string" target="item_id" target-type="string" target-header="K8s Stateful Set" error-skip="true" resource-description="Unique string to distinguish a resource from others in the system" target-description="Item ID"/>
+            <field resource="cluster_name" source-type="string" target="cluster_name" target-type="string" target-header="K8s Stateful Set" resource-description="AWS resource name" resource-description-manual="true" target-description="Cluster Name"/>
+            <field resource="cluster_url" source-type="string" target="cluster_url" target-type="string" target-header="K8s Stateful Set" resource-description="Kubernetes cluster API server URL" resource-description-manual="true" target-description="Cluster Url"/>
+            <field resource="creation_timestamp" source-type="datetime" target="creation_timestamp" target-type="datetime" target-header="K8s Stateful Set" min-length="1" max-length="255" resource-description="Date and time when the resource was created" resource-description-manual="true" target-description="Creation Timestamp"/>
+              <!-- AWS K8s Stateful Set -->
+            <field resource="resource_version" source-type="string" target="resource_version" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255" resource-description="Kubernetes resource version for optimistic concurrency" resource-description-manual="true" target-description="Resource Version"/>
+            <field resource="namespace" source-type="string" target="namespace" target-type="string" target-header="AWS K8s Stateful Set" min-length="1" max-length="255" resource-description="Kubernetes namespace" resource-description-manual="true" target-description="Namespace"/>
+          </mapping>
+        </task>
+
+        <!-- Azure RELATIONSHIPS -->
+        <task enable="true" name="Azure Public IP to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  infra.cloudinfrastructure_name                                      AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS subscription_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  netport.port                                                   AS netport_name,
+                  format('Netport-%s', netport.netport_pk)                       AS netport_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  subnet.name                                                    AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)                          AS subnet_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_subnet_v1 subnet
+                JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  resource.resource_name                                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)                         AS rg_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_resourcerelationship_v2 rr ON rr.to_ip_address_fk = ip.ipaddress_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  np.port                                     AS netport_name,
+                  format('Netport-%s', np.netport_pk)         AS netport_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_netport_v1 np
+                JOIN view_resourcerelationship_v2 rr ON rr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 infra ON np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE np.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Subnet to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Subnet to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                  <target/>
+                  <resource doql="
+                  SELECT
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)       AS subnet_device42_id,
+                    resource.resource_name                      AS rg_name,
+                    format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                  FROM
+                    view_subnet_v1 subnet
+                  JOIN view_resourcerelationship_v2 rr ON rr.to_subnet_fk = subnet.subnet_pk
+                  JOIN view_resource_v2 resource on resource.resource_pk = rr.from_resource_fk
+                  JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                  JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                  JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                  WHERE vrfgroup.cloudinfrastructure_fk is not null AND resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="subnet_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="subnet_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                                         AS resource_name,
+                  format('Resource-%s', resource.resource_pk)                    AS resource_device42_id,
+                  infra.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                AND (resource.vendor_resource_type = 'Disk'
+                OR resource.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource.category)
+                OR resource.category @> ARRAY['azureKeyVault']
+                OR resource.category @> ARRAY['resource_group', 'Azure']
+                OR resource.vendor_resource_type = 'Application Gateway')
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Resources to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure Resources to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource2.resource_name                             AS resource_name,
+                  format('Resource-%s', resource2.resource_pk)        AS resource_device42_id,
+                  resource.resource_name                              AS rg_name,
+                  format('Resource-%s', resource.resource_pk)         AS rg_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_resourcerelationship_v2 rel ON rel.to_resource_fk = resource.resource_pk
+                JOIN view_resource_v2 resource2 ON resource2.resource_pk = rel.from_resource_fk
+                WHERE resource.category @> ARRAY['resource_group', 'Azure']
+                AND (resource2.vendor_resource_type = 'Disk'
+                OR resource2.vendor_resource_type = 'Network Security Group'
+                OR 'azure_image' = ANY(resource2.category)
+                OR resource2.category @> ARRAY['azureKeyVault']
+                OR resource2.vendor_resource_type = 'Application Gateway')              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Image to Azure VM" type="asset_relationship" description="Create Relationship from Azure Image to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Azure Image'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Disk to Azure VM" type="asset_relationship" description="Create Relationship from Azure Disk to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  resource.resource_name                      AS resource_name,
+                  format('Resource-%s', resource.resource_pk) AS resource_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', rel.device_fk)          AS device_device42_id
+                FROM
+                  view_resource_v2 resource
+                JOIN view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                JOIN view_device_v2 device ON device.device_pk = rel.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft' AND resource.vendor_resource_type = 'Disk'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Network Interface to Azure VM" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                  format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                               AS device_name,
+                  format('Device-%s', device.device_pk)                             AS device_device42_id
+                FROM
+                  view_netport_v1 netport
+                JOIN view_device_v2 as device ON device.device_pk = netport.device_fk
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure Public IP to Azure VM" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure VM" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                      ELSE cloud_instance.instance_name
+                    END
+                  END                                                                 AS device_name,
+                  format('Device-%s', device.device_pk)                               AS device_device42_id
+                FROM
+                  view_ipaddress_v2 ip
+                JOIN view_device_v2 as device ON device.device_pk = ANY(ip.device_fks)
+                JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                      AS device_name,
+                  format('Device-%s', device.device_pk)    AS device_device42_id,
+                  subnet.name                              AS subnet_name,
+                  format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                JOIN view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                JOIN view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                JOIN view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+                WHERE v.name = 'Microsoft' and subnet.name != 'undefined'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Subscription" type="asset_relationship" description="Create Relationship from Azure VM to Azure Subscription" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                                         AS device_name,
+                  format('Device-%s', device.device_pk)                       AS device_device42_id,
+                  ci.cloudinfrastructure_name                                 AS subscription_name,
+                  format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS subscription_device42_id
+                FROM
+                  view_device_v2 device
+                INNER JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subscription_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subscription_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM to Azure Resource Group" type="asset_relationship" description="Create Relationship from Azure VM to Azure Resource Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                         AS device_name,
+                  format('Device-%s', device.device_pk)       AS device_device42_id,
+                  resource.resource_name                      AS rg_name,
+                  format('Resource-%s', resource.resource_pk) AS rg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_deviceresource_v1 rel ON rel.device_fk = device.device_pk
+                JOIN view_resource_v2 resource ON resource.resource_pk = rel.resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND rel.relation = 'device_resource_group'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="rg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="rg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+
+        <task enable="true" name="Azure VM ( netport ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( netport ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_netport_v1 np ON np.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 nr ON nr.to_netport_fk = np.netport_pk
+                JOIN view_resource_v2 res ON res.resource_pk = nr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND nr.relation = 'security_group_netports'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure VM ( subnet ) to Azure Security Group" type="asset_relationship" description="Create Relationship from Azure VM ( subnet ) to Azure Security Group" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  CASE
+                    WHEN position('/' IN device.name) > 0 THEN
+                    substring(device.name FROM position('/' IN device.name) + 1)
+                    ELSE
+                    CASE
+                      WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                      ELSE cid.instance_name
+                    END
+                  END                                    AS device_name,
+                  format('Device-%s', device.device_pk)  AS device_device42_id,
+                  res.resource_name                      AS sg_name,
+                  format('Resource-%s', res.resource_pk) AS sg_device42_id
+                FROM
+                  view_device_v2 device
+                JOIN view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                JOIN view_ipaddress_v1 ip ON ip.device_fk = device.device_pk
+                JOIN view_resourcerelationship_v2 sr ON sr.to_subnet_fk = ip.subnet_fk
+                JOIN view_resource_v2 res ON res.resource_pk = sr.from_resource_fk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                JOIN view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                WHERE v.name = 'Microsoft' AND sr.relation = 'security_group_subnets'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="sg_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="sg_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+      </task>
+
+
+      <task enable="true" name="Azure Network Interface to Azure Subnet" type="asset_relationship" description="Create Relationship from Azure Network Interface to Azure Subnet" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                with azure_np as (
+                     select netport.port,netport.netport_pk,netport.cloudinfrastructure_fk
+                     from
+                     view_netport_v1 netport
+                     JOIN view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+                )
+                SELECT
+                  format('Subnet-%s', s.subnet_pk)                      AS subnet_device42_id,
+                  s.name                                                AS subnet_name,
+                  format('Netport-%s', np.netport_pk)                   AS netport_device42_id,
+                  np.port                                               AS netport_name
+                FROM
+                  view_subnet_v1 s
+                JOIN view_vrfgroup_v1 vrfgroup ON s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                JOIN view_cloudinfrastructure_v2 infra ON vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                JOIN view_ipaddress_v2 ip on ip.subnet_fk = s.subnet_pk
+                JOIN azure_np np on np.netport_pk = ip.netport_fk
+                WHERE infra.account_id is not null AND vendor.name = 'Microsoft'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="netport_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="netport_name"></mapping>
+      </task>
+
+      <task enable="true" name="Azure Public IP to Azure Network Interafce" type="asset_relationship" description="Create Relationship from Azure Public IP to Azure Network Interface" d42_min_version="19.05.00">
+              <api>
+                <target/>
+                <resource doql="
+                SELECT
+                  format('Netport-%s', np.netport_pk)                                 AS netport_device42_id,
+                  np.port                                                             AS netport_name,
+                  format('IP-%s', ip.ipaddress_pk)                                    AS ip_device42_id,
+                  COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS ip_name
+                FROM
+                  view_netport_v1 np
+                JOIN view_ipaddress_v2 ip ON ip.netport_fk = np.netport_pk
+                JOIN view_cloudinfrastructure_v2 ci ON ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                JOIN view_vendor_v1 v ON v.vendor_pk = ci.cloud_vendor_fk
+                WHERE v.name = 'Microsoft' and ip.is_public = True
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="netport_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="netport_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+      </task>
+
+       <!-- AWS RELATIONSHIPS -->
+       <!-- Has -->
+       <task enable="true" name="AWS VM to AWS Disk" type="asset_relationship" description="Create Relationship from AWS VM to AWS Disk" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EBS' AND resource.category @> ARRAY['Storage', 'Block Storage'] AND rel.relation = 'Attached' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="resource_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Network" type="asset_relationship" description="Create Relationship from AWS VM to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT
+                     coalesce(netport.vendor_custom_fields -> 'Name', netport.port)    AS network_name,
+                     format('Netport-%s', netport.netport_pk)                         AS network_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                              AS device_name,
+                     format('Device-%s', device.device_pk)                             AS device_device42_id
+
+              FROM
+                     view_netport_v1 netport
+              INNER JOIN 
+                     view_device_v2 as device ON device.device_pk = netport.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN 
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE infra.account_id is not null AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Network Interface to AWS Public IP" type="asset_relationship" description="Create Relationship from AWS Network Interface to AWS Public IP" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            WITH amazon_infra AS (
+								SELECT infra.cloudinfrastructure_pk
+								FROM view_cloudinfrastructure_v2 infra
+								INNER JOIN view_vendor_v1 vendor
+									ON infra.cloud_vendor_fk = vendor.vendor_pk
+								WHERE vendor.name = 'Amazon'
+								  AND infra.account_id IS NOT NULL
+							),
+							amazon_networks AS (
+								SELECT
+									network.port,
+									network.netport_pk,
+									network.vendor_custom_fields
+								FROM view_netport_v1 network
+								INNER JOIN amazon_infra
+									ON network.cloudinfrastructure_fk = amazon_infra.cloudinfrastructure_pk
+							)
+							SELECT
+								coalesce(NULLIF(an.vendor_custom_fields -> 'Name', ''), an.port) AS network_name,
+								format('Netport-%s', an.netport_pk)                              AS network_device42_id,
+								COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))              AS ip_name,
+								format('IP-%s', ip.ipaddress_pk)                                 AS ip_device42_id
+							FROM view_ipaddress_v2 ip
+							INNER JOIN amazon_networks an
+								ON an.port = ip.details ->> 'network_interface_id'
+							WHERE ip.is_public = true
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="network_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Public IP to AWS VM" type="asset_relationship" description="Create Relationship from AWS Public IP to AWS VM" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              select
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+              END                                                               AS device_name,
+              format('Device-%s', device.device_pk)                             AS device_device42_id,
+                     COALESCE(NULLIF(ip.label, ''), host(ip.ip_address))        AS ip_name,
+                     format('IP-%s', ip.ipaddress_pk)                           AS ip_device42_id
+              FROM
+                     view_ipaddress_v2 ip
+              JOIN view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              JOIN view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              INNER JOIN view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk 
+              INNER JOIN view_device_v2 device on ipd.device_fk = device.device_pk 
+              INNER JOIN view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              WHERE ip.cloudinfrastructure_fk is not null AND ip.is_public = True AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="ip_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name"></mapping>
+       </task>
+
+       <!-- Receives Traffic -->
+       <task enable="true" name="AWS VM to AWS Application LB" type="asset_relationship" description="Create Relationship from AWS VM to AWS Application LB" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name                                             AS resource_name,
+                     format('Resource-%s', resource.resource_pk)                        AS resource_device42_id,
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END                                                                 AS device_name,
+                     format('Device-%s', device.device_pk)                               AS device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_resourcerelationship_v2 rel ON rel.from_resource_fk = resource.resource_pk
+              JOIN
+                     view_resource_v2 targetgroup ON targetgroup.resource_pk = rel.to_resource_fk
+              JOIN 
+                     view_deviceresource_v1 devrel ON devrel.resource_fk = targetgroup.resource_pk
+              JOIN 
+                     view_device_v2 device ON device.device_pk = devrel.device_fk
+              LEFT JOIN
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Elastic Load Balancer' AND resource.category @> ARRAY['LB', 'ALB'] AND rel.relation = 'elb_target_groups' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Routes Traffic" upstream-relationship="Receives Traffic" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Uses -->
+       <task enable="true" name="AWS VM to AWS Key Pair" type="asset_relationship" description="Create Relationship from AWS VM to AWS Key Pair" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'EC2 Key Pair' AND resource.category @> ARRAY['AWS', 'Key Pair'] AND rel.relation = 'Used By' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+       </task>
+
+       <!-- Contained By -->
+
+       <task enable="true" name="AWS VM to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS VM to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     CASE
+                     WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                     ELSE
+                            CASE
+                                   WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                   ELSE cid.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', device.device_pk)    AS device_device42_id,
+                     subnet.name                              AS subnet_name,
+                     format('Subnet-%s', subnet.subnet_pk)    AS subnet_device42_id
+              FROM
+                     view_device_v2 device
+              INNER JOIN
+                     view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+              INNER JOIN 
+                     view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account  
+              INNER JOIN 
+                     view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk 
+              INNER JOIN 
+                     view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk 
+              INNER JOIN 
+                     view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+              INNER JOIN 
+                     view_subnet_v1 subnet on subnet.subnet_pk = ip.subnet_fk
+              INNER JOIN 
+                     view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+              WHERE 
+              v.name = 'Amazon' and subnet.name != 'undefined' and ci.account_id is not null
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS VM to AWS Security Group" type="asset_relationship" description="Create Relationship from AWS VM to AWS Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+              SELECT 
+                     resource.resource_name as resource_name,
+                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                     CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                            CASE
+                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                   ELSE cloud_instance.instance_name
+                            END
+                     END as device_name,
+                     format('Device-%s', rel.device_fk) as device_device42_id
+              FROM
+                     view_resource_v2 resource
+              INNER JOIN
+                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+              LEFT JOIN 
+                     view_device_v2 device ON device.device_pk = rel.device_fk
+              LEFT JOIN 
+                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+              LEFT JOIN
+                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+              LEFT JOIN
+                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+              WHERE
+                     resource.vendor_resource_type = 'Security Group' AND resource.category @> ARRAY['AWS', 'security_group'] AND rel.relation = 'Security Group' AND vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS Subnet to AWS Network" type="asset_relationship" description="Create Relationship from AWS Subnet to AWS Network" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            select
+                                   coalesce(network.vendor_custom_fields -> 'Name', network.port)   AS network_name,
+                                   format('Netport-%s', network.netport_pk)                         AS network_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            FROM
+                                   d42_readonly.view_netport_v1 network
+                            INNER JOIN 
+                                          d42_readonly.view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id' 
+                            LEFT JOIN
+                                   d42_readonly.view_cloudinfrastructure_v2 infra ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            LEFT JOIN 
+                                   d42_readonly.view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id is not null and vendor.name = 'Amazon'
+              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="network_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+       </task>
+
+       <task enable="true" name="AWS RDS to AWS Subnet" type="asset_relationship" description="Create Relationship from AWS RDS to AWS Subnet" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                            SELECT 
+                                   rds.resource_name                                                AS resource_name,
+                                   format('Resource-%s', rds.resource_pk)                           AS resource_device42_id,
+                                   subnet.name                                                      AS subnet_name,
+                                   format('Subnet-%s', subnet.subnet_pk)                            AS subnet_device42_id
+                            from
+                                   view_resource_v2 rds
+                            inner join
+                                   view_subnet_v1 subnet on subnet.details ->> 'vendor_subnet_id' = any(select jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb)) 
+                            inner join 
+                                   view_vrfgroup_v1 vrf on subnet.vrfgroup_fk = vrf.vrfgroup_pk 
+                            inner join 
+                                   view_cloudinfrastructure_v2 infra on vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk 
+                            INNER JOIN 
+                                   view_vendor_v1 v on infra.cloud_vendor_fk = v.vendor_pk 
+                            WHERE 
+                                   subnet.name != 'undefined' and rds.vendor_resource_type = 'RDS' AND rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node'] and not rds.category @> array['Cluster'] and v.name = 'Amazon'
+                     "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="subnet_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- Provision From -->
+       <task enable="true" name="AWS Image to AWS VM" type="asset_relationship" description="Create Relationship from AWS Image to AWS VM" d42_min_version="19.05.00">
+              <api>
+                    <target/>
+                    <resource doql="
+                    SELECT 
+                        image.resource_name as resource_name,
+                        format('Resource-%s', image.resource_pk) as resource_device42_id,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END 
+                        END as device_name,
+                        format('Device-%s', device.device_pk) as device_device42_id
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN 
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN 
+                        view_resource_v2 image on device.details ->> 'image_id' = image.identifier
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.vendor_resource_type = 'AWS Image' AND image.category @> ARRAY['AWS', 'AMI', 'AWS Image', 'image'] AND vendor.name = 'Amazon'
+               "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="device_device42_id"/>
+                     <source-2 device42-id="resource_device42_id"/>
+              </matching>
+              <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+       </task>
+
+       <!-- AWS K8s Relationships -->
+      <task enable="true" name="AWS K8s Namespace To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Namespace To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            n.resource_name namespace_name,
+                            r.resource_name as item_name,
+                            format('Resource-%s', n.resource_pk) AS ns_device42_id,
+                            format('Resource-%s', r.resource_pk) AS item_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                     where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                            and n.category @> array['namespace', 'Kubernetes']
+                     )
+                     SELECT
+                     r.namespace_name,
+                     r.item_name,
+                     r.ns_device42_id,
+                     r.item_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ns_device42_id"/>
+                <source-2 device42-id="item_device42_id"/>
+            </matching>
+            <mapping key="namespace_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="item_name">
+            </mapping>
+        </task>
+
+       <task enable="true" name="AWS K8s Node To AWS K8s Pod Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Node To AWS K8s Pods" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                        select
+                                dn.name node_name,
+                                pod.resource_name as pod_name,
+                                format('Device-%s', dr.device_fk) AS node_device42_id,
+                                format('Resource-%s', pod.resource_pk) AS pod_device42_id,
+                                node.resource_pk node_resource_pk,
+                                pod.resource_pk pod_resource_pk,
+                                node.cloudinfrastructure_fk
+                        from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                        where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                     )
+                     SELECT
+                        r.node_name,
+                        r.pod_name,
+                        r.node_device42_id,
+                        r.pod_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="node_device42_id"/>
+                <source-2 device42-id="pod_device42_id"/>
+            </matching>
+            <mapping key="node_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="pod_name">
+            </mapping>
+        </task>
+
+      <task enable="true" name="AWS K8s Daemon Set To AWS K8s Config Map Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Daemon Set To AWS K8s Config Map" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as ds_name,
+                            c.resource_name as cm_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                            c.resource_pk,
+                            c.cloudinfrastructure_fk
+                     from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where c.category @> array['config_map', 'Kubernetes']
+                            and d.category @> array['daemon_set', 'Kubernetes']
+                     )
+                     SELECT
+                     r.ds_name,
+                     r.cm_name,
+                     r.ds_device42_id,
+                     r.cm_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="cm_device42_id"/>
+            </matching>
+            <mapping key="ds_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="cm_name">
+            </mapping>
+        </task>
+
+
+      <task enable="true" name="AWS K8s Deployment To AWS K8s Replica Set Relationships" type="asset_relationship" description="Create Relationship from AWS K8s Deployment To AWS K8s Replica Set" d42_min_version="19.05.00">
+            <api>
+              <target />
+              <resource
+              doql="
+                     WITH k8sres as (
+                     select
+                            d.resource_name as dp_name,
+                            r.resource_name as rs_name,
+                            format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                            format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                            r.resource_pk,
+                            r.cloudinfrastructure_fk
+                     from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                            inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                     where r.category @> array['replica_set', 'Kubernetes']
+                            and d.category @> array['deployment', 'Kubernetes']
+                     )
+                     SELECT
+                     r.dp_name,
+                     r.rs_name,
+                     r.ds_device42_id,
+                     r.rs_device42_id
+                     FROM
+                            k8sres r
+                            inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                            inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                     WHERE
+                            v.name = 'Amazon'
+                     "
+                     />
+            </api>
+            <matching>
+                <source-1 device42-id="ds_device42_id"/>
+                <source-2 device42-id="rs_device42_id"/>
+            </matching>
+            <mapping key="dp_name" downstream-relationship="Uses" upstream-relationship="Owned By" target-key="rs_name">
+            </mapping>
+        </task>
+
+        <!-- GCP RELATIONSHIPS -->
+        <!-- Has -->
+        <task enable="true" name="GCP Network Interface to GCP Public IP" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP Public IP" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                WITH google_infra AS (
+                    SELECT infra.cloudinfrastructure_pk
+                    FROM view_cloudinfrastructure_v2 infra
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+                      AND infra.account_id IS NOT NULL
+                ),
+                google_networks AS (
+                    SELECT
+                        network.port,
+                        network.netport_pk,
+                        network.vendor_custom_fields,
+                        network.details
+                    FROM view_netport_v1 network
+                    INNER JOIN google_infra
+                        ON network.cloudinfrastructure_fk = google_infra.cloudinfrastructure_pk
+                )
+                SELECT
+                    coalesce(NULLIF(gn.vendor_custom_fields -> 'Name', ''), gn.port) AS network_name,
+                    format('Netport-%s', gn.netport_pk)                              AS network_device42_id,
+                    ip.details ->> 'name'                                            AS ip_name,
+                    format('IP-%s', ip.ipaddress_pk)                                 AS ip_device42_id
+                FROM view_ipaddress_v2 ip
+                INNER JOIN google_networks gn
+                    ON gn.port = ip.details ->> 'port'
+                    AND gn.details ->> 'nat_ip' = host(ip.ip_address)
+                WHERE ip.is_public = true
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Network Interface to GCP VM" type="asset_relationship" description="Create Relationship from GCP Network Interface to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS network_name,
+                    format('Netport-%s', netport.netport_pk)                          AS network_device42_id,
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                ELSE cloud_instance.instance_name
+                            END
+                    END                                                               AS device_name,
+                    format('Device-%s', device.device_pk)                            AS device_device42_id
+
+                FROM
+                    view_netport_v1 netport
+                LEFT JOIN
+                    view_device_v2 device ON device.device_pk = netport.device_fk
+                LEFT JOIN
+                    view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                LEFT JOIN
+                    view_cloudinfrastructure_v2 infra ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                LEFT JOIN
+                    view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE infra.account_id is not null AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="network_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Public IP to GCP VM" type="asset_relationship" description="Create Relationship from GCP Public IP to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                        SELECT
+                            CASE
+                                WHEN position('/' IN device.name) > 0 THEN
+                                    substring(device.name FROM position('/' IN device.name) + 1)
+                                ELSE
+                                    CASE
+                                        WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                        ELSE cloud_instance.instance_name
+                                    END
+                            END                                                               AS device_name,
+                            format('Device-%s', device.device_pk)                            AS device_device42_id,
+                            ip.details ->> 'name'                                            AS ip_name,
+                            format('IP-%s', ip.ipaddress_pk)                                AS ip_device42_id
+                        FROM
+                            view_ipaddress_v2 ip
+                        JOIN
+                            view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                        JOIN
+                            view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                        INNER JOIN
+                            view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                        INNER JOIN
+                            view_device_v2 device on ipd.device_fk = device.device_pk
+                        INNER JOIN
+                            view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                        WHERE
+                            ip.cloudinfrastructure_fk is not null
+                            AND ip.is_public = True
+                            AND vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="ip_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="ip_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Disk to GCP VM" type="asset_relationship" description="Create Relationship from GCP Disk to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                                SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                         WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                         ELSE
+                                             CASE
+                                                 WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                 ELSE cloud_instance.instance_name
+                                              END
+                                      END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                                 FROM
+                                     view_resource_v2 resource
+                                 INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                                 LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                                 LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                                 LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                 LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                 WHERE
+                                      resource.category @> ARRAY['GCP', 'disk']  AND vendor.name = 'Google' AND resource.vendor_resource_type = 'Cloud Disk'
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="resource_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To"
+                     target-key="resource_name">
+            </mapping>
+        </task>
+
+        <!-- Provision From -->
+        <task enable="true" name="GCP Image to GCP VM" type="asset_relationship" description="Create Relationship from GCP Image to GCP VM" d42_min_version="19.05.00">
+			  <api>
+					<target/>
+					<resource doql="
+					SELECT
+						image.resource_name as resource_name,
+						format('Resource-%s', image.resource_pk) as resource_device42_id,
+						CASE
+							WHEN position('/' IN device.name) > 0 THEN
+								substring(device.name FROM position('/' IN device.name) + 1)
+							ELSE
+								CASE
+									WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+									ELSE cloud_instance.instance_name
+								END
+						END as device_name,
+						format('Device-%s', device.device_pk) as device_device42_id
+					FROM
+						view_device_v2 device
+					INNER JOIN
+						view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+					INNER JOIN
+						view_resource_v2 image on cloud_instance.image_id = image.resource_name
+					LEFT JOIN
+						view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+					LEFT JOIN
+						view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+					WHERE
+						image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+			   "
+			  />
+			  </api>
+			  <matching>
+					 <source-1 device42-id="device_device42_id"/>
+					 <source-2 device42-id="resource_device42_id"/>
+			  </matching>
+			  <mapping key="device_name" downstream-relationship="Provisioned From" upstream-relationship="Provisioned" target-key="resource_name"></mapping>
+		</task>
+
+        <!-- Contains -->
+
+        <task enable="true" name="GCP VM to GCP Security Group" type="asset_relationship" description="Create Relationship from GCP VM to GCP Security Group" d42_min_version="19.05.00">
+              <api>
+                     <target/>
+                     <resource doql="
+                              SELECT
+                                     resource.resource_name as resource_name,
+                                     format('Resource-%s', rel.resource_fk) as resource_device42_id,
+                                     CASE
+                                            WHEN position('/' IN device.name) > 0 THEN
+                                            substring(device.name FROM position('/' IN device.name) + 1)
+                                            ELSE
+                                            CASE
+                                                   WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                                   ELSE cloud_instance.instance_name
+                                            END
+                                     END as device_name,
+                                     format('Device-%s', rel.device_fk) as device_device42_id
+                              FROM
+                                     view_resource_v2 resource
+                              INNER JOIN
+                                     view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                              LEFT JOIN
+                                     view_device_v2 device ON device.device_pk = rel.device_fk
+                              LEFT JOIN
+                                     view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                              LEFT JOIN
+                                     view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                              LEFT JOIN
+                                     view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                              WHERE
+                                     resource.category @> ARRAY['gcp_firewall_rule'] AND rel.relation = 'Security Group' AND vendor.name = 'Google'
+                              "
+              />
+              </api>
+              <matching>
+                     <source-1 device42-id="resource_device42_id"/>
+                     <source-2 device42-id="device_device42_id"/>
+              </matching>
+              <mapping key="resource_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+       </task>
+
+       <task enable="true" name="GCP Subnet to GCP VM" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP VM" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    CASE
+                        WHEN position('/' IN device.name) > 0 THEN
+                            substring(device.name FROM position('/' IN device.name) + 1)
+                        ELSE
+                            CASE
+                                WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                ELSE cid.instance_name
+                            END
+                    END as device_name,
+                    format('Device-%s', device.device_pk)    AS device_device42_id,
+                    subnet.name                                 AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)        AS subnet_device42_id
+                FROM
+                    view_device_v2 device
+                INNER JOIN
+                    view_netport_v1 netport ON device.device_pk = netport.device_fk
+                INNER JOIN
+                    view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                INNER JOIN
+                    view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                INNER JOIN
+                    view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                INNER JOIN
+                    view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                INNER JOIN
+                    view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN
+                    view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                WHERE
+                v.name = 'Google'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains" upstream-relationship="Contained By"
+                     target-key="device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" name="GCP Subnet to GCP Network Interface" type="asset_relationship" description="Create Relationship from GCP Subnet to GCP Network Interface" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                SELECT DISTINCT
+                    coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)    AS netport_name,
+                    format('Netport-%s', netport.netport_pk)                     AS netport_device42_id,
+                    coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name)    AS subnet_name,
+                    format('Subnet-%s', subnet.subnet_pk)                         AS subnet_device42_id
+                FROM view_netport_v1 netport
+                INNER JOIN view_vrfgroup_v1 vrf
+                    ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                INNER JOIN view_subnet_v1 subnet
+                    ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                INNER JOIN view_cloudinfrastructure_v2 infra
+                    ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                INNER JOIN view_vendor_v1 vendor
+                    ON infra.cloud_vendor_fk = vendor.vendor_pk
+                WHERE vendor.name = 'Google'
+                "/>
+            </api>
+            <matching>
+                <source-1 device42-id="subnet_device42_id"/>
+                <source-2 device42-id="netport_device42_id"/>
+            </matching>
+            <mapping key="subnet_name" downstream-relationship="Contains"
+                     upstream-relationship="Contained By" target-key="netport_name">
+            </mapping>
+        </task>
+        <!-- END GCP RELATIONSHIPS -->
+
+        <!-- VMWARE RELATIONSHIPS -->
+        <task enable="true" name="VMWARE Datacenter to Datastore" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Datastore relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_datastore' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="datastore_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="datastore_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Host" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datacenter to Network" type="asset_relationship" description="Sync Device42 VMWare Datacenter to Network relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datacenter.resource_name                         AS datacenter_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS datacenter_device42_id,
+                            network.resource_name                            AS network_name,
+                            format('Resource-%s', network.resource_pk)       AS network_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.from_resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 network
+                            ON rel.to_resource_fk = network.resource_pk
+                     WHERE 
+                            rel.relation = 'datacenter_network' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter'] 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datacenter_device42_id"/>
+                <source-2 device42-id="network_device42_id"/>
+            </matching>
+            <mapping key="datacenter_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="network_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Host" type="asset_relationship" description="Sync Device42 VMWare Datastore to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                          AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)     AS datastore_device42_id,
+                            device.name                                      AS device_name,
+                            format('Device-%s', device.device_pk)            AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Used By" upstream-relationship="Uses" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Datastore to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Datastore to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            datastore.resource_name                        AS datastore_name,
+                            format('Resource-%s', datastore.resource_pk)   AS datastore_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="datastore_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="datastore_name" downstream-relationship="Provides storage for" upstream-relationship="Stored on" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Host to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Host to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            virtual_host.name                               AS host_name,
+                            format('Device-%s', virtual_host.device_pk)     AS host_device42_id,
+                            virtual_device.name                             AS virtual_device_name,
+                            format('Device-%s', virtual_device.device_pk)   AS virtual_device_device42_id
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="host_device42_id"/>
+                <source-2 device42-id="virtual_device_device42_id"/>
+            </matching>
+            <mapping key="host_name" downstream-relationship="Has Registered" upstream-relationship="Is Registered On" target-key="virtual_device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Network to Host" type="asset_relationship" description="Sync Device42 VMWare Network to Host relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Provides" upstream-relationship="Provided By" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Network to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Network to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            network.resource_name                          AS network_name,
+                            format('Resource-%s', network.resource_pk)     AS network_device42_id,
+                            device.name                                    AS device_name,
+                            format('Device-%s', device.device_pk)          AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="network_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="network_name" downstream-relationship="Connects" upstream-relationship="Connected By" target-key="device_name"></mapping>
+        </task>
+       <task enable="true" name="VMWARE Resource Pool to Virtual Machine" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Virtual Machine relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool.resource_name                          AS resource_pool_name,
+                            format('Resource-%s', resource_pool.resource_pk)     AS resource_pool_device42_id,
+                            device.name                                          AS device_name,
+                            format('Device-%s', device.device_pk)                AS device_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_device42_id"/>
+                <source-2 device42-id="device_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_name" downstream-relationship="Defines Resources for" upstream-relationship="Gets Resources from" target-key="device_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Resource Pool to Resource Pool" type="asset_relationship" description="Sync Device42 VMWare Resource Pool to Resource Pool relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            resource_pool_1.resource_name                         AS resource_pool_1_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)    AS resource_pool_1_device42_id,
+                            resource_pool_2.resource_name                         AS resource_pool_2_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)    AS resource_pool_2_device42_id
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="resource_pool_1_device42_id"/>
+                <source-2 device42-id="resource_pool_2_device42_id"/>
+            </matching>
+            <mapping key="resource_pool_1_name" downstream-relationship="Contains" upstream-relationship="Contained By" target-key="resource_pool_2_name"></mapping>
+        </task>
+        <task enable="true" name="VMWARE Virtual Machine to Disk" type="asset_relationship" description="Sync Device42 VMWare Virtual Machine to Disk relationship" d42_min_version="19.05.00">
+            <api>
+                <target/>
+                <resource doql="
+                     SELECT
+                            device.name                                 AS device_name,
+                            format('Device-%s', device.device_pk)       AS device_device42_id,
+                            disk.details ->> 'file_name'                AS disk_name,
+                            format('Resource-%s', disk.resource_pk)     AS disk_device42_id
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+                <source-2 device42-id="disk_device42_id"/>
+            </matching>
+            <mapping key="device_name" downstream-relationship="Has" upstream-relationship="Is Attached To" target-key="disk_name"></mapping>
+        </task>
+        <!-- END VMWARE RELATIONSHIPS -->
+
+        <task enable="true" type="asset" description="Delete assets from Freshservice that do not exist in Device42">
+            <api>
+                <target delete="true"/>
+                <resource
+                         
+                          doql="
+                                select
+                                    format('Device-%s', d.device_pk) as device42_id
+                                from view_device_v2 d
+
+                                union
+
+                                select
+                                    format('Resource-%s', r.resource_pk) as device42_id
+                                from view_resource_v2 r
+
+                                union
+
+                                select
+                                    format('Subnet-%s', s.subnet_pk) as device42_id
+                                from view_subnet_v1 s
+
+                                union
+
+                                select
+                                    format('VPC-%s', v.vrfgroup_pk) as device42_id
+                                from view_vrfgroup_v1 v
+
+                                union
+
+                                select
+                                   format('IP-%s', i.ipaddress_pk) as device42_id
+                                 from view_ipaddress_v2 i
+
+                                union
+
+                                select
+                                    format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) as device42_id
+                                from view_cloudinfrastructure_v2 ci
+
+                                union
+
+                                select
+                                    format('BusinessApp-%s', ba.businessapplication_pk) as device42_id
+                                from view_businessapplication_v1 ba
+
+                                union
+
+                                select
+                                    format('Netport-%s', np.netport_pk) as device42_id
+                                from view_netport_v1 np
+                               "
+                />
+            </api>
+            <matching>
+                <source-1 device42-id="device42_id"/>
+            </matching>
+            <mapping source="Devices"/>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_min_version="16.19.00">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+                                   WITH k8s_node_details as (
+                                          select d.device_fk                                     AS device_fk, 
+                                                 'AWS K8s Node'                                  AS asset_type,
+                                                 format('Resource-%s', n.k8snode_pk)
+                                          from view_k8snode_v2 n inner join view_deviceresource_v1 d on d.resource_fk = n.k8snode_pk
+                                                 inner join view_resource_v2 c on n.k8scluster_fk = c.resource_pk 
+                                                 inner join view_resource_v2 k on n.k8snode_pk = k.resource_pk 
+                                                 inner join view_cloudinfrastructure_v2 i on k.cloudinfrastructure_fk = i.cloudinfrastructure_pk 
+                                                 inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                                          where n.category @> ARRAY['node', 'Kubernetes'] and v.name = 'Amazon'                                   )
+					, device as
+							(
+								SELECT
+                                    case
+                                        WHEN k8snode.asset_type is not null THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host AND lower(view_device_v2.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v2.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'tablet' or lower(view_hardware_v2.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'laptop' or lower(view_hardware_v2.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND (lower(view_device_v2.physicalsubtype) = 'mobile' or lower(view_hardware_v2.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) &lt;&gt; 'laptop' AND view_device_v2.details ->> 'imei' is not null THEN 'Mobile'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'workstation' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'network printer' THEN 'Printer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'router' THEN 'Router'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'firewall' THEN 'Firewall'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.physicalsubtype) = 'access point' THEN 'Access Point'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v2.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v2.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'physical' AND lower(view_device_v2.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND view_device_v2.details ->> 'template' is null or (view_device_v2.details ->> 'template')::boolean = false THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'vmware' AND (view_device_v2.details ->> 'template')::boolean = true THEN 'Image'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(view_device_v2.virtualsubtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v2.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v2.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v2.device_pk,
+									view_device_v2.name,
+                                    format('Device-%s', view_device_v2.device_pk) as device42_id,
+									view_device_v2.last_edited
+								FROM view_device_v2
+								left outer join view_cloudinstance_v1 ci on view_device_v2.device_pk = ci.device_fk
+                                                        left outer join view_hardware_v2 on view_device_v2.hardware_fk = view_hardware_v2.hardware_pk
+                                LEFT JOIN k8s_node_details k8snode  ON view_device_v2.device_pk = k8snode.device_fk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+                     "/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="software_installation" description="Delete software installations from Freshservice that do not exist in Device42" d42_max_version="16.18.02">
+            <api>
+                <target delete="true"/>
+                <resource
+                          doql="
+							WITH device as
+							(
+								SELECT
+                                    case
+                                        WHEN view_device_v1.virtual_host AND lower(view_device_v1.os_name) like '%esxi%' THEN 'Computer'
+                                        WHEN view_device_v1.virtual_host THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'tablet' or lower(view_hardware_v1.name) like '%ipad%') THEN 'Tablet'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'laptop' or lower(view_hardware_v1.name) like '%macbook%') THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND (lower(view_device_v1.sub_type) = 'mobile' or lower(view_hardware_v1.name) like '%iphone%') THEN 'Mobile'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.os_name) similar to '%(f5|netscaler)%' THEN 'Load Balancer'
+                                        WHEN view_device_v1.network_device THEN 'Switch'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(windows|microsoft)%' AND lower(view_device_v1.os_name) like '%server%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(unix|z/os|z os|zos|hp-ux|os400|os/400|os 400|linux|amazon|ubuntu|centos|redhat|debian|sles|suse|gentoo|oracle|freebsd|rhel|red hat|fedora|alma|rocky|arch)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(aix)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'physical' AND lower(view_device_v1.os_name) similar to '%(solaris|sunos|sun os)%' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'vmware' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'amazon ec2 instance' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'azure virtual machine' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(view_device_v1.virtual_subtype) = 'gce' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' AND lower(ci.service_name) = 'azure load balancer' THEN 'Azure LB'
+                                        WHEN lower(view_device_v1.type) = 'physical' THEN 'Computer'
+                                        WHEN lower(view_device_v1.type) = 'virtual' THEN 'Computer'
+                                        ELSE 'Computer'
+                                    END as asset_type,
+									view_device_v1.device_pk,
+									view_device_v1.name,
+                                    format('Device-%s', view_device_v1.device_pk) as device42_id,
+									view_device_v1.last_edited
+								FROM view_device_v1
+								left outer join view_cloudinstance_v1 ci on view_device_v1.device_pk = ci.device_fk
+								left outer join view_hardware_v1 on view_device_v1.hardware_fk = view_hardware_v1.hardware_pk
+							)
+							, latest_softwareinuse AS (
+							    SELECT view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk, MAX(softwareinuse_pk) AS max_pk
+							    FROM view_softwareinuse_v1
+							    GROUP BY view_softwareinuse_v1.software_fk, view_softwareinuse_v1.device_fk
+							)
+							select device.device42_id as device_device42_id,
+							trim(view_software_v1.name) as software_name, view_softwareinuse_v1.version from view_softwareinuse_v1
+							inner join latest_softwareinuse on view_softwareinuse_v1.softwareinuse_pk = latest_softwareinuse.max_pk
+							left join view_software_v1 on view_softwareinuse_v1.software_fk=software_pk inner join device on view_softwareinuse_v1.device_fk=device_pk
+							where device.asset_type = 'Computer'
+						"/>
+            </api>
+            <matching>
+                <source-1 device42-id="device_device42_id"/>
+            </matching>
+            <mapping software-name="software_name" version="version">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_max_version="19.04.99">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                          doql="
+                                SELECT DISTINCT
+                                       d1.name                                         AS dependent_device_name,
+                                       format('Device-%s', df1.dependent_device_fk)    AS dependent_device_device42_id,
+                                       'Connected to'                                  AS downstream_relationship,
+                                       d2.name                                         AS dependency_device_name,
+                                       format('Device-%s', df1.dependency_device_fk)   AS dependency_device_device42_id,
+                                       'Connected to'                                  AS upstream_relationship
+                                 FROM   view_deviceaffinity_v2 df1
+                                 INNER JOIN view_device_v1 d1
+                                       ON d1.device_pk = df1.dependent_device_fk
+                                 INNER JOIN view_device_v1 d2
+                                       ON d2.device_pk = df1.dependency_device_fk
+                                 WHERE  df1.dependent_device_fk IS NOT NULL
+                                 AND    df1.dependent_device_fk &lt;&gt; df1.dependency_device_fk
+                                 AND    df1.effective_to IS NULL
+                                
+                                union
+
+                                select 
+                                   case connection_type when 'reversed' then d2.name else d1.name end as dependent_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d2.device_pk) else format('Device-%s', d1.device_pk) end as dependent_device_device42_id,
+                                   'Connected to' as downstream_relationship,
+                                   case connection_type when 'reversed' then d1.name else d2.name end as dependency_device_name,
+                                   case connection_type when 'reversed' then format('Device-%s', d1.device_pk) else format('Device-%s', d2.device_pk) end as dependency_device_device42_id,
+                                   'Connected to' as upstream_relationship
+                                from view_businessapplicationconnection_v1 bc
+                                join view_businessapplicationelement_v1 be1 on bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                                inner join view_device_v1 d1 on be1.device_fk = d1.device_pk
+                                join view_businessapplicationelement_v1 be2 on bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                                inner join view_device_v1 d2 on be2.device_fk = d2.device_pk
+                                
+                                union
+
+                                select 
+                                   ba.name as dependent_device_name,
+                                   format('BusinessApp-%s', ba.businessapplication_pk) as dependent_device_device42_id,
+                                   'Hosted On' as downstream_relationship,
+                                   d.name as dependency_device_name,
+                                   format('Device-%s', d.device_pk) as dependency_device_device42_id,
+                                   'Hosts' as upstream_relationship
+                                from view_businessapplication_v1 ba
+                                join view_businessapplicationelement_v1 bae on ba.businessapplication_pk = bae.businessapplication_fk
+                                join view_device_v1 d on bae.device_fk = d.device_pk
+                                
+                                union
+								
+                                select * from (
+                                WITH
+                                   host_device AS (
+                                        select d.device_pk, d.name
+                                        from view_device_v1 d
+                                        where d.virtual_host
+                                   ),
+                                   vm_device as (
+                                        select d.device_pk, d.name,
+                                        d.virtual_host_device_fk
+                                        from view_device_v1 d
+                                        where lower(d.type) = 'virtual'
+                                   )
+
+                                select
+                                   vmd.name as dependent_device_name,
+                                   format('Device-%s', vmd.device_pk) as dependent_device_device42_id,
+                                   'Virtualized by' as downstream_relationship,
+                                   hd.name as dependency_device_name,
+                                   format('Device-%s', hd.device_pk) as dependency_device_device42_id,
+                                   'Virtualizes' as upstream_relationship
+                                from host_device hd
+                                inner join vm_device vmd on hd.device_pk = vmd.virtual_host_device_fk
+				                ) r
+                                
+                                union
+
+                                select 
+					dc.name as dependent_device_name,
+					format('Device-%s', dc.device_pk) as dependent_device_device42_id,
+                                   'Member of' as downstream_relationship,
+					dp.name as dependency_device_name,
+					format('Device-%s', dp.device_pk) as dependency_device_device42_id,
+                                   'Includes' as upstream_relationship
+                                from view_devices_in_cluster_v1 dic
+                                inner join view_device_v2 dp on dic.parent_device_fk = dp.device_pk
+                                inner join view_device_v2 dc on dic.child_device_fk = dc.device_pk
+                                where lower(dp.type) = 'cluster'
+                               "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+        </task>
+
+        <task enable="true" type="asset_relationship" description="Delete asset relationships from Freshservice that do not exist in Device42" d42_min_version="19.05.00">
+            <api>
+                <target
+                        delete="true"/>
+                <resource
+                     doql= "
+                     WITH RECURSIVE
+                     allrels AS (
+                         SELECT
+                             rel.applicationgrouprelationship_pk AS rel_id,
+                             rel.is_dependency,
+                             from_ci.applicationgroupconfigitem_pk AS from_ci_id,
+                             from_ci.configitem_type AS from_ci_type,
+                             from_ci.device_fk AS from_device_fk,
+                             fp.applicationgroupconfigitem_pk AS from_parent_ci_id,
+                             fp.configitem_type AS from_parent_ci_type,
+                             fp.device_fk AS from_parent_device_fk,
+                             to_ci.applicationgroupconfigitem_pk AS to_ci_id,
+                             to_ci.configitem_type AS to_ci_type,
+                             to_ci.device_fk AS to_device_fk,
+                             tp.applicationgroupconfigitem_pk AS to_parent_ci_id,
+                             tp.configitem_type AS to_parent_ci_type,
+                             tp.device_fk AS to_parent_device_fk
+                         FROM view_applicationgrouprelationship_v2 rel
+                         JOIN view_applicationgroup_v2 ag
+                             ON ag.applicationgroup_pk = rel.applicationgroup_fk AND ag.status_id = 1
+                         JOIN view_applicationgroupconfigitem_v2 from_ci
+                             ON from_ci.applicationgroupconfigitem_pk = rel.from_applicationgroupconfigitem_fk
+                         LEFT JOIN view_applicationgroupconfigitem_v2 fp
+                             ON fp.applicationgroupconfigitem_pk = from_ci.parent_applicationgroupconfigitem_fk
+                         JOIN view_applicationgroupconfigitem_v2 to_ci
+                             ON to_ci.applicationgroupconfigitem_pk = rel.to_applicationgroupconfigitem_fk
+                         LEFT JOIN view_applicationgroupconfigitem_v2 tp
+                             ON tp.applicationgroupconfigitem_pk = to_ci.parent_applicationgroupconfigitem_fk
+                         WHERE rel.effective_to IS NULL
+                     ),
+                     global_nonapp_device_rels AS (
+                         SELECT DISTINCT ON (
+                             COALESCE(from_parent_ci_id, from_ci_id),
+                             COALESCE(to_parent_ci_id, to_ci_id),
+                             is_dependency
+                         )
+                             COALESCE(from_parent_ci_id, from_ci_id) AS from_ci_id,
+                             COALESCE(from_parent_device_fk, from_device_fk) AS from_device_fk,
+                             COALESCE(to_parent_ci_id, to_ci_id) AS to_ci_id,
+                             COALESCE(to_parent_device_fk, to_device_fk) AS to_device_fk,
+                             is_dependency
+                         FROM allrels
+                         WHERE (is_dependency = true OR to_ci_type &lt;&gt; 'appcomp')
+                           AND COALESCE(from_parent_ci_type, from_ci_type) = 'device'
+                           AND COALESCE(to_parent_ci_type, to_ci_type) = 'device'
+                           AND COALESCE(from_parent_ci_id, from_ci_id)
+                            &lt;&gt; COALESCE(to_parent_ci_id, to_ci_id)
+                     ),
+                     all_appcomp_rels AS (
+                         SELECT * FROM allrels
+                         WHERE is_dependency = false AND to_ci_type = 'appcomp'
+                     ),
+                     appcomp_chain AS (
+                         SELECT
+                             aar.rel_id,
+                             ARRAY[aar.rel_id] AS path_ids,
+                             aar.is_dependency,
+                             aar.from_ci_id, aar.from_ci_type, aar.from_device_fk,
+                             aar.from_parent_ci_id, aar.from_parent_ci_type, aar.from_parent_device_fk,
+                             aar.to_ci_id, aar.to_ci_type, aar.to_device_fk,
+                             aar.to_parent_ci_id, aar.to_parent_ci_type, aar.to_parent_device_fk,
+                             (aar.from_ci_type = 'appcomp' AND aar.to_ci_type = 'appcomp') AS app_to_app,
+                             (aar.to_parent_ci_id IS NOT NULL) AS stop_chain
+                         FROM all_appcomp_rels aar
+                         UNION ALL
+                         SELECT
+                             ac.rel_id,
+                             ac.path_ids || dep.rel_id,
+                             CASE WHEN ac.from_ci_type &lt;&gt; 'appcomp' AND dep.from_ci_type &lt;&gt; 'appcomp'
+                                  THEN true ELSE ac.is_dependency END,
+                             ac.from_ci_id, ac.from_ci_type, ac.from_device_fk,
+                             ac.from_parent_ci_id, ac.from_parent_ci_type, ac.from_parent_device_fk,
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_ci_id ELSE dep.to_ci_id END,
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_ci_type ELSE dep.to_ci_type END,
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_device_fk ELSE dep.to_device_fk END,
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_parent_ci_id ELSE dep.to_parent_ci_id END,
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_parent_ci_type ELSE dep.to_parent_ci_type END,
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN dep.from_parent_device_fk ELSE dep.to_parent_device_fk END,
+                             ac.app_to_app OR (dep.from_ci_type = 'appcomp' AND dep.to_ci_type = 'appcomp'),
+                             CASE WHEN ac.app_to_app AND dep.from_ci_type &lt;&gt; 'appcomp' THEN true
+                                  WHEN dep.to_parent_ci_id IS NOT NULL THEN true
+                                  ELSE false END
+                         FROM all_appcomp_rels dep, appcomp_chain ac
+                         WHERE NOT ac.stop_chain
+                           AND NOT dep.rel_id = ANY(ac.path_ids)
+                           AND (
+                               (dep.from_ci_type = 'appcomp' AND dep.to_ci_type = 'appcomp' AND dep.from_ci_id = ac.to_ci_id)
+                               OR (ac.app_to_app AND dep.to_ci_id = ac.to_ci_id AND dep.from_ci_type &lt;&gt; 'appcomp')
+                           )
+                     ),
+                     appcomp_chain_device_rels AS (
+                         SELECT DISTINCT ON (
+                             COALESCE(from_parent_ci_id, from_ci_id),
+                             COALESCE(to_parent_ci_id, to_ci_id)
+                         )
+                             COALESCE(from_parent_ci_id, from_ci_id) AS from_ci_id,
+                             COALESCE(from_parent_device_fk, from_device_fk) AS from_device_fk,
+                             COALESCE(to_parent_ci_id, to_ci_id) AS to_ci_id,
+                             COALESCE(to_parent_device_fk, to_device_fk) AS to_device_fk,
+                             is_dependency
+                         FROM appcomp_chain
+                         WHERE from_ci_id &lt;&gt; to_ci_id
+                           AND COALESCE(from_parent_ci_type, from_ci_type) = 'device'
+                           AND COALESCE(to_parent_ci_type, to_ci_type) = 'device'
+                           AND COALESCE(from_parent_ci_id, from_ci_id)
+                            &lt;&gt; COALESCE(to_parent_ci_id, to_ci_id)
+                     ),
+                     appcomp_internal_device_rels AS (
+                         SELECT DISTINCT ON (
+                             COALESCE(dep.from_parent_ci_id, dep.from_ci_id),
+                             COALESCE(aar.from_parent_ci_id, aar.from_ci_id)
+                         )
+                             COALESCE(dep.from_parent_ci_id, dep.from_ci_id) AS from_ci_id,
+                             COALESCE(dep.from_parent_device_fk, dep.from_device_fk) AS from_device_fk,
+                             COALESCE(aar.from_parent_ci_id, aar.from_ci_id) AS to_ci_id,
+                             COALESCE(aar.from_parent_device_fk, aar.from_device_fk) AS to_device_fk,
+                             false AS is_dependency
+                         FROM all_appcomp_rels aar
+                         JOIN all_appcomp_rels dep ON aar.to_ci_id = dep.to_ci_id
+                         WHERE aar.from_ci_type &lt;&gt; 'appcomp' AND dep.from_ci_type &lt;&gt; 'appcomp'
+                           AND aar.rel_id &lt; dep.rel_id
+                           AND COALESCE(dep.from_parent_ci_type, dep.from_ci_type) = 'device'
+                           AND COALESCE(aar.from_parent_ci_type, aar.from_ci_type) = 'device'
+                           AND COALESCE(dep.from_parent_ci_id, dep.from_ci_id)
+                            &lt;&gt; COALESCE(aar.from_parent_ci_id, aar.from_ci_id)
+                     )
+                     SELECT DISTINCT
+                         d1.name                              AS dependent_device_name,
+                         format('Device-%s', d1.device_pk)    AS dependent_device_device42_id,
+                         'Connected to'                       AS downstream_relationship,
+                         d2.name                              AS dependency_device_name,
+                         format('Device-%s', d2.device_pk)    AS dependency_device_device42_id,
+                         'Connected to'                       AS upstream_relationship
+                     FROM (
+                         SELECT from_device_fk, to_device_fk FROM global_nonapp_device_rels
+                         UNION
+                         SELECT ac.from_device_fk, ac.to_device_fk
+                         FROM appcomp_chain_device_rels ac
+                         WHERE ac.from_ci_id &lt;&gt; ac.to_ci_id
+                           AND NOT EXISTS (
+                               SELECT 1 FROM global_nonapp_device_rels g
+                               WHERE g.from_ci_id = ac.from_ci_id AND g.to_ci_id = ac.to_ci_id
+                           )
+                           AND NOT EXISTS (
+                               SELECT 1 FROM global_nonapp_device_rels g
+                               WHERE ac.is_dependency = false
+                                 AND g.from_ci_id = ac.to_ci_id AND g.to_ci_id = ac.from_ci_id
+                           )
+                         UNION
+                         SELECT ai.from_device_fk, ai.to_device_fk
+                         FROM appcomp_internal_device_rels ai
+                         WHERE NOT EXISTS (
+                             SELECT 1 FROM appcomp_chain_device_rels ac
+                             WHERE ac.from_ci_id = ai.to_ci_id AND ac.to_ci_id = ai.from_ci_id
+                         )
+                         AND NOT EXISTS (
+                             SELECT 1 FROM global_nonapp_device_rels g
+                             WHERE g.from_ci_id = ai.from_ci_id AND g.to_ci_id = ai.to_ci_id
+                         )
+                         AND NOT EXISTS (
+                             SELECT 1 FROM global_nonapp_device_rels g
+                             WHERE g.from_ci_id = ai.to_ci_id AND g.to_ci_id = ai.from_ci_id
+                         )
+                     ) combined
+                     JOIN view_device_v1 d1 ON d1.device_pk = combined.from_device_fk
+                     JOIN view_device_v1 d2 ON d2.device_pk = combined.to_device_fk
+
+                     UNION
+
+                     SELECT
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d2.NAME
+                                          ELSE d1.NAME
+                            END AS dependent_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d2.device_pk)
+                                          ELSE format('Device-%s', d1.device_pk)
+                            END            AS dependent_device_device42_id,
+                            'Connected to' AS downstream_relationship,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN d1.NAME
+                                          ELSE d2.NAME
+                            END AS dependency_device_name,
+                            CASE connection_type
+                                          WHEN 'reversed' THEN format('Device-%s', d1.device_pk)
+                                          ELSE format('Device-%s', d2.device_pk)
+                            END            AS dependency_device_device42_id,
+                            'Connected to' AS upstream_relationship
+                     FROM       view_businessapplicationconnection_v1 bc
+                     JOIN       view_businessapplicationelement_v1 be1
+                     ON         bc.from_businessapplicationelement_fk = be1.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d1
+                     ON         be1.device_fk = d1.device_pk
+                     JOIN       view_businessapplicationelement_v1 be2
+                     ON         bc.to_businessapplicationelement_fk = be2.businessapplicationelement_pk
+                     INNER JOIN view_device_v1 d2
+                     ON         be2.device_fk = d2.device_pk
+
+                     UNION
+
+                     SELECT ba.NAME                                             AS dependent_device_name,
+                            format('BusinessApp-%s', ba.businessapplication_pk) AS dependent_device_device42_id,
+                            'Hosted On'                                         AS downstream_relationship,
+                            d.NAME                                              AS dependency_device_name,
+                            format('Device-%s', d.device_pk)                    AS dependency_device_device42_id,
+                            'Hosts'                                             AS upstream_relationship
+                     FROM   view_businessapplication_v1 ba
+                     JOIN   view_businessapplicationelement_v1 bae
+                     ON     ba.businessapplication_pk = bae.businessapplication_fk
+                     JOIN   view_device_v1 d
+                     ON     bae.device_fk = d.device_pk
+
+                     UNION
+
+                     SELECT *
+                     FROM   ( WITH host_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME
+                                   FROM   view_device_v1 d
+                                   WHERE  d.virtual_host ), vm_device AS
+                            (
+                                   SELECT d.device_pk,
+                                          d.NAME,
+                                          d.virtual_host_device_fk
+                                   FROM   view_device_v1 d
+                                   WHERE  lower(d.type) = 'virtual' )SELECT     vmd.NAME                           AS dependent_device_name,
+                            Format('Device-%s', vmd.device_pk) AS dependent_device_device42_id,
+                            'Virtualized by'                   AS downstream_relationship,
+                            hd.NAME                            AS dependency_device_name,
+                            Format('Device-%s', hd.device_pk)  AS dependency_device_device42_id,
+                            'Virtualizes'                      AS upstream_relationship
+                     FROM       host_device hd
+                     INNER JOIN vm_device vmd
+                     ON         hd.device_pk = vmd.virtual_host_device_fk )
+
+                     UNION
+
+                     SELECT     dc.NAME                           AS dependent_device_name,
+                            format('Device-%s', dc.device_pk) AS dependent_device_device42_id,
+                            'Member of'                       AS downstream_relationship,
+                            dp.NAME                           AS dependency_device_name,
+                            format('Device-%s', dp.device_pk) AS dependency_device_device42_id,
+                            'Includes'                        AS upstream_relationship
+                     FROM       view_devices_in_cluster_v1 dic
+                     INNER JOIN view_device_v2 dp
+                     ON         dic.parent_device_fk = dp.device_pk
+                     INNER JOIN view_device_v2 dc
+                     ON         dic.child_device_fk = dc.device_pk
+                     WHERE      lower(dp.type) = 'cluster'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                    AS dependent_device_name,
+                            format('Device-%s', rel.device_fk)     AS dependent_device_device42_id,
+                            'Has'                                  AS downstream_relationship,
+                            resource.resource_name                 AS dependency_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependency_device_device42_id,
+                            'Is Attached To'                       AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EBS'
+                     AND        resource.category @> array['Storage', 'Block Storage']
+                     AND        rel.relation = 'Attached'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                 AS dependent_device_name,
+                            format('Device-%s', device.device_pk)               AS dependent_device_device42_id,
+                            'Has'                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.label, ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                    AS dependency_device_device42_id,
+                            'Is Attached To'                                    AS upstream_relationship
+                     FROM       view_ipaddress_v2 ip
+                     JOIN       view_cloudinfrastructure_v2 infra
+                     ON         ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN       view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipd
+                     ON         ipd.ipaddress_fk = ip.ipaddress_pk
+                     INNER JOIN view_device_v2 device
+                     ON         ipd.device_fk = device.device_pk
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     WHERE      ip.cloudinfrastructure_fk IS NOT NULL
+                     AND        ip.is_public = true
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                                 CASE
+                                                        WHEN cloud_instance.instance_name IS NULL
+                                                        OR        cloud_instance.instance_name = '' THEN device.NAME
+                                                        ELSE cloud_instance.instance_name
+                                                 END
+                            END                                                            AS dependent_device_name,
+                            format('Device-%s', device.device_pk)                          AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                                               AS upstream_relationship
+                     FROM      view_netport_v1 netport
+                     INNER JOIN view_device_v2 AS device
+                     ON        device.device_pk = netport.device_fk
+                     LEFT JOIN view_cloudinstance_v1 cloud_instance
+                     ON        cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN view_cloudinfrastructure_v2 infra
+                     ON        netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN view_vendor_v1 vendor
+                     ON        infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE     infra.account_id IS NOT NULL
+                     AND       vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT *
+                        FROM   ( WITH amazon_netports AS MATERIALIZED (
+                                        SELECT network.netport_pk,
+                                               network.port,
+                                               network.vendor_custom_fields
+                                        FROM   view_netport_v1 network
+                                        INNER JOIN view_cloudinfrastructure_v2 infra
+                                            ON network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                                        INNER JOIN view_vendor_v1 vendor
+                                            ON infra.cloud_vendor_fk = vendor.vendor_pk
+                                        WHERE  infra.account_id IS NOT NULL
+                                        AND    vendor.NAME = 'Amazon'
+                                      ),
+                                      public_ip_with_network_id AS MATERIALIZED (
+                                        SELECT ip.ipaddress_pk,
+                                               ip.label,
+                                               ip.ip_address,
+                                               ip.details ->> 'network_interface_id' AS network_interface_id
+                                        FROM   view_ipaddress_v2 ip
+                                        WHERE  ip.is_public = true
+                                        AND    ip.details ->> 'network_interface_id' IS NOT NULL
+                                      )
+                                      SELECT
+                                             COALESCE(NULLIF(anp.vendor_custom_fields -> 'Name', ''), anp.port) AS dependent_device_name,
+                                             format('Netport-%s', anp.netport_pk)                               AS dependent_device_device42_id,
+                                             'Has'                                                               AS downstream_relationship,
+                                             COALESCE(NULLIF(pip.label, ''), host(pip.ip_address))               AS dependency_device_name,
+                                             format('IP-%s', pip.ipaddress_pk)                                   AS dependency_device_device42_id,
+                                             'Is Attached To'                                                    AS upstream_relationship
+                                      FROM   public_ip_with_network_id pip
+                                      INNER JOIN amazon_netports anp
+                                          ON anp.port = pip.network_interface_id
+                               )
+
+                     UNION
+
+                     SELECT     resource.resource_name                  AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Routes Traffic'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Receives Traffic'                    AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_resourcerelationship_v2 rel
+                     ON         rel.from_resource_fk = resource.resource_pk
+                     INNER JOIN  view_resource_v2 targetgroup
+                     ON         targetgroup.resource_pk = rel.to_resource_fk
+                     INNER JOIN  view_deviceresource_v1 devrel
+                     ON         devrel.resource_fk = targetgroup.resource_pk
+                     INNER JOIN  view_device_v2 device
+                     ON         device.device_pk = devrel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Elastic Load Balancer'
+                     AND        resource.category @> array['LB', 'ALB']
+                     AND        rel.relation = 'elb_target_groups'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Used By'                              AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Uses'                             AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'EC2 Key Pair'
+                     AND        resource.category @> array['AWS', 'Key Pair']
+                     AND        rel.relation = 'Used By'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     INNER JOIN view_ipaddress_device_v2 ipr
+                     ON         ipr.device_fk = device.device_pk
+                     INNER JOIN view_ipaddress_v2 ip
+                     ON         ip.ipaddress_pk = ipr.ipaddress_fk
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.subnet_pk = ip.subnet_fk
+                     INNER JOIN view_vrfgroup_v1 vrfgroup ON subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                            and vrfgroup.cloudinfrastructure_fk = ci.cloudinfrastructure_pk
+                     WHERE      v.NAME = 'Amazon'
+                     AND        subnet.NAME != 'undefined' and ci.account_id is not null
+
+                     UNION
+
+                     SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.vendor_resource_type = 'Security Group'
+                     AND        resource.category @> array['AWS', 'security_group']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+
+                     SELECT     subnet.NAME                                                    AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            COALESCE(network.vendor_custom_fields -> 'Name', network.port) AS dependency_device_name,
+                            format('Netport-%s', network.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM       d42_readonly.view_netport_v1 network
+                     INNER JOIN d42_readonly.view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = network.details ->> 'subnet_id'
+                     LEFT JOIN  d42_readonly.view_cloudinfrastructure_v2 infra
+                     ON         network.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  d42_readonly.view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      infra.account_id IS NOT NULL
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT     subnet.NAME                            AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)  AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            rds.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', rds.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM       view_resource_v2 rds
+                     INNER JOIN view_subnet_v1 subnet
+                     ON         subnet.details ->> 'vendor_subnet_id' = ANY
+                            (
+                                   SELECT jsonb_array_elements_text(COALESCE(rds.details ->> 'subnets', '[]')::jsonb))
+                     INNER JOIN view_vrfgroup_v1 vrf
+                     ON         subnet.vrfgroup_fk = vrf.vrfgroup_pk
+                     INNER JOIN view_cloudinfrastructure_v2 infra
+                     ON         vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     INNER JOIN view_vendor_v1 v
+                     ON         infra.cloud_vendor_fk = v.vendor_pk
+                     WHERE      subnet.NAME != 'undefined'
+                     AND        rds.vendor_resource_type = 'RDS'
+                     AND        rds.category &amp;&amp; ARRAY['Database Instance', 'Cluster_Node']
+                     AND
+                     NOT rds.category @> array['Cluster']
+                     AND
+                     v.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                      AS dependent_device_name,
+                            format('Device-%s', device.device_pk)    AS dependent_device_device42_id,
+                            'Provisioned From'                       AS downstream_relationship,
+                            image.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', image.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                            AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     INNER JOIN view_resource_v2 image
+                     ON         device.details ->> 'image_id' = image.identifier
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      image.vendor_resource_type = 'AWS Image'
+                     AND        image.category @> array['AWS', 'AMI', 'AWS Image', 'image']
+                     AND        vendor.NAME = 'Amazon'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                      AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk)      AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            netport.port                                                   AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            subnet.NAME                                                    AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)                          AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                                              AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)                         AS dependent_device_device42_id,
+                            'Contains'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Contained By'                                                      AS upstream_relationship
+                     FROM   view_ipaddress_v2 ip
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_ip_address_fk = ip.ipaddress_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  ip.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = ip.cloudinfrastructure_fk
+                     AND    ip.is_public = true
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            np.port                                     AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk)         AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     np.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  np.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = np.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            subnet.NAME                                 AS dependency_device_name,
+                            format('Subnet-%s', subnet.subnet_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_subnet_v1 subnet
+                     JOIN   view_resourcerelationship_v2 rr
+                     ON     rr.to_subnet_fk = subnet.subnet_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rr.from_resource_fk
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     subnet.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  vrfgroup.cloudinfrastructure_fk IS NOT NULL
+                     AND    resource.cloudinfrastructure_fk = vrfgroup.cloudinfrastructure_fk
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT 
+                            infra.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', infra.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                     AS downstream_relationship,
+                            resource.resource_name                                         AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk)                    AS dependency_device_device42_id,
+                            'Contained By'                                                 AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    (
+                                   resource.vendor_resource_type = 'Disk'
+                            OR     resource.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource.category)
+                            OR     resource.category @> array['azureKeyVault']
+                            OR     resource.category @> array['resource_group', 'Azure']
+                            OR     resource.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            resource.resource_name                       AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk)  AS dependent_device_device42_id,
+                            'Contains'                                   AS downstream_relationship,
+                            resource2.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource2.resource_pk) AS dependency_device_device42_id,
+                            'Contained By'                               AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_resourcerelationship_v2 rel
+                     ON     rel.from_resource_fk = resource.resource_pk
+                     JOIN   view_resource_v2 resource2
+                     ON     resource2.resource_pk = rel.to_resource_fk
+                     WHERE  resource.category @> array['resource_group', 'Azure']
+                     AND    (
+                                   resource2.vendor_resource_type = 'Disk'
+                            OR     resource2.vendor_resource_type = 'Network Security Group'
+                            OR     'azure_image' = ANY(resource2.category)
+                            OR     resource2.category @> ARRAY['azureKeyVault']
+                            OR     resource2.vendor_resource_type = 'Application Gateway')
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Provisioned From'                          AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Provisioned'                      AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Azure Image'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                AS dependent_device_name,
+                            format('Device-%s', rel.device_fk) AS dependent_device_device42_id,
+                            'Has'                                       AS downstream_relationship,
+                            resource.resource_name                      AS dependency_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependency_device_device42_id,
+                            'Is Attached To'                   AS upstream_relationship
+                     FROM   view_resource_v2 resource
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.resource_fk = resource.resource_pk
+                     JOIN   view_device_v2 device
+                     ON     device.device_pk = rel.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+                     AND    resource.vendor_resource_type = 'Disk'
+
+                     UNION
+
+                     SELECT 
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cloud_instance.instance_name IS NULL
+                                                 OR     cloud_instance.instance_name = '' THEN device.NAME
+                                                 ELSE cloud_instance.instance_name
+                                          END
+                            END                                   AS dependent_device_name,
+                            format('Device-%s', device.device_pk) AS dependent_device_device42_id,
+                            'Has'                                                          AS downstream_relationship,
+                            COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                            format('Netport-%s', netport.netport_pk)                       AS dependency_device_device42_id,
+                            'Is Attached To'                      AS upstream_relationship
+                     FROM   view_netport_v1 netport
+                     JOIN   view_device_v2 AS device
+                     ON     device.device_pk = netport.device_fk
+                     JOIN   view_cloudinstance_v1 cloud_instance
+                     ON     cloud_instance.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT * FROM (
+                         WITH ms_infra AS MATERIALIZED (
+                            SELECT infra.cloudinfrastructure_pk
+                            FROM   view_cloudinfrastructure_v2 infra
+                            JOIN   view_vendor_v1 vendor
+                                   ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE  vendor.name = 'Microsoft'
+                         ),
+                         all_public_ips AS MATERIALIZED (
+                            SELECT ip.ipaddress_pk,
+                                   ip.ip_address,
+                                   ip.details,
+                                   ip.cloudinfrastructure_fk
+                            FROM   view_ipaddress_v2 ip
+                            WHERE  ip.is_public = true
+                            AND    ip.cloudinfrastructure_fk IS NOT NULL
+                         )
+                         SELECT CASE
+                                   WHEN position('/' IN device.name) > 0
+                                       THEN substring(device.name FROM position('/' IN device.name) + 1)
+                                   ELSE COALESCE(NULLIF(cloud_instance.instance_name, ''), device.name)
+                               END                                                                   AS dependent_device_name,
+                               format('Device-%s', device.device_pk)                                 AS dependent_device_device42_id,
+                               'Has'                                                                 AS downstream_relationship,
+                               COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address))   AS dependency_device_name,
+                               format('IP-%s', ip.ipaddress_pk)                                      AS dependency_device_device42_id,
+                               'Is Attached To'                                                      AS upstream_relationship
+                         FROM   all_public_ips ip
+                         INNER JOIN ms_infra mi
+                               ON ip.cloudinfrastructure_fk = mi.cloudinfrastructure_pk
+                         INNER JOIN view_ipaddress_device_v2 ipd
+                               ON ipd.ipaddress_fk = ip.ipaddress_pk
+                         INNER JOIN view_device_v1 device
+                               ON device.device_pk = ipd.device_fk
+                         INNER JOIN view_cloudinstance_v1 cloud_instance
+                               ON cloud_instance.device_fk = device.device_pk
+                     )
+
+                     UNION
+
+                     SELECT
+                            subnet.NAME                           AS dependent_device_name,
+                            format('Subnet-%s', subnet.subnet_pk) AS dependent_device_device42_id,
+                            'Contains'                            AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                   AS dependency_device_name,
+                            format('Device-%s', device.device_pk) AS dependency_device_device42_id,
+                            'Contained By'                        AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     JOIN   view_ipaddress_device_v2 ipr
+                     ON     ipr.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.ipaddress_pk = ipr.ipaddress_fk
+                     JOIN   view_subnet_v1 subnet
+                     ON     subnet.subnet_pk = ip.subnet_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    subnet.NAME != 'undefined'
+
+                     UNION
+
+                     SELECT
+                            ci.cloudinfrastructure_name                                 AS dependent_device_name,
+                            format('CloudInfrastructure-%s', ci.cloudinfrastructure_pk) AS dependent_device_device42_id,
+                            'Contains'                                                  AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cid.instance_name IS NULL
+                                                               OR         cid.instance_name = '' THEN device.NAME
+                                                               ELSE cid.instance_name
+                                                 END
+                            END                                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                       AS dependency_device_device42_id,
+                            'Contained By'                                              AS upstream_relationship
+                     FROM       view_device_v2 device
+                     INNER JOIN view_cloudinstance_v1 cid
+                     ON         cid.device_fk = device.device_pk
+                     INNER JOIN view_cloudinfrastructure_v2 ci
+                     ON         ci.account_id = cid.account
+                     INNER JOIN view_vendor_v1 v
+                     ON         ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE      v.NAME = 'Microsoft'
+
+                     UNION
+
+                     SELECT
+                            resource.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', resource.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                                  AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                         AS dependency_device_name,
+                            format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                            'Contained By'                              AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_deviceresource_v1 rel
+                     ON     rel.device_fk = device.device_pk
+                     JOIN   view_resource_v2 resource
+                     ON     resource.resource_pk = rel.resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    rel.relation = 'device_resource_group'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 nr
+                     ON     nr.to_netport_fk = np.netport_pk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = nr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    nr.relation = 'security_group_netports'
+
+                     UNION
+
+                     SELECT
+                            res.resource_name                      AS dependent_device_name,
+                            format('Resource-%s', res.resource_pk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                   WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                   ELSE
+                                          CASE
+                                                 WHEN cid.instance_name IS NULL
+                                                 OR     cid.instance_name = '' THEN device.NAME
+                                                 ELSE cid.instance_name
+                                          END
+                            END                                    AS dependency_device_name,
+                            format('Device-%s', device.device_pk)  AS dependency_device_device42_id,
+                            'Contained By'                         AS upstream_relationship
+                     FROM   view_device_v2 device
+                     JOIN   view_cloudinstance_v1 cid
+                     ON     cid.device_fk = device.device_pk
+                     JOIN   view_ipaddress_v1 ip
+                     ON     ip.device_fk = device.device_pk
+                     JOIN   view_resourcerelationship_v2 sr
+                     ON     sr.to_subnet_fk = ip.subnet_fk
+                     JOIN   view_resource_v2 res
+                     ON     res.resource_pk = sr.from_resource_fk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.account_id = cid.account
+                     JOIN   view_vendor_v1 v
+                     ON     ci.cloud_vendor_fk = v.vendor_pk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    sr.relation = 'security_group_subnets'
+
+                     UNION
+
+                     SELECT 
+                            s.NAME                              AS dependent_device_name,
+                            format('Subnet-%s', s.subnet_pk)    AS dependent_device_device42_id,
+                            'Contains'                          AS downstream_relationship,
+                            np.port                             AS dependency_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependency_device_device42_id,
+                            'Contained By'                      AS upstream_relationship
+                     FROM   view_subnet_v1 s
+                     JOIN   view_vrfgroup_v1 vrfgroup
+                     ON     s.vrfgroup_fk = vrfgroup.vrfgroup_pk
+                     JOIN   view_cloudinfrastructure_v2 infra
+                     ON     vrfgroup.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     JOIN   view_vendor_v1 vendor
+                     ON     infra.cloud_vendor_fk = vendor.vendor_pk
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.subnet_fk = s.subnet_pk
+                     JOIN   view_netport_v1 np
+                     ON     np.netport_pk = ip.netport_fk
+                     WHERE  infra.account_id IS NOT NULL
+                     AND    vendor.NAME = 'Microsoft'
+
+                     UNION
+                     
+                     SELECT 
+                            np.port                                                             AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk)                                 AS dependent_device_device42_id,
+                            'Has'                                                               AS downstream_relationship,
+                            COALESCE(NULLIF(ip.details ->> 'ip_name', ''), host(ip.ip_address)) AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk)                                    AS dependency_device_device42_id,
+                            'Is Attached To'                                                    AS upstream_relationship
+                     FROM   view_netport_v1 np
+                     JOIN   view_ipaddress_v2 ip
+                     ON     ip.netport_fk = np.netport_pk
+                     JOIN   view_cloudinfrastructure_v2 ci
+                     ON     ci.cloudinfrastructure_pk = ip.cloudinfrastructure_fk
+                     JOIN   view_vendor_v1 v
+                     ON     v.vendor_pk = ci.cloud_vendor_fk
+                     WHERE  v.NAME = 'Microsoft'
+                     AND    ip.is_public = true
+
+                     UNION
+
+                     select * from ( WITH k8sres as (
+                            select
+                                   n.resource_name dependent_device_name,
+                                   r.resource_name as dependency_device_name,
+                                   format('Resource-%s', n.resource_pk) AS dependent_device_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS dependency_device_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 n on n.resource_pk = l.from_resource_fk
+                            where r.category &amp;&amp; array['pod', 'deployment', 'service', 'daemon_set','replica_set', 'cron_job', 'config_map', 'stateful_set']
+                                   and n.category @> array['namespace', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+
+                     select * from (WITH k8sres_pod as (
+                            select
+                                   dn.name dependent_device_name,
+                                   pod.resource_name as dependency_device_name,
+                                   format('Device-%s', dr.device_fk) AS dependent_device_device42_id,
+                                   format('Resource-%s', pod.resource_pk) AS dependency_device_device42_id,
+                                   node.resource_pk node_resource_pk,
+                                   pod.resource_pk pod_resource_pk,
+                                   node.cloudinfrastructure_fk
+                            from view_resource_v2 node inner join view_resourcerelationship_v2 rel on node.resource_pk = rel.to_resource_fk
+                                   inner join view_resource_v2 pod on pod.resource_pk = rel.from_resource_fk
+                                   inner join view_deviceresource_v1 dr on dr.resource_fk = node.resource_pk
+                                   inner join view_device_v2 dn on dn.device_pk = dr.device_fk
+                            where pod.category @> array['pod', 'Kubernetes'] and node.category @> array['node', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dependent_device_name,
+                            r.dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.dependency_device_name,
+                            r.dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres_pod r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon') l
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as ds_name,
+                                   c.resource_name as cm_name,
+                                   format('Resource-%s', d.resource_pk) AS ds_device42_id,
+                                   format('Resource-%s', c.resource_pk) AS cm_device42_id,
+                                   c.resource_pk,
+                                   c.cloudinfrastructure_fk
+                            from view_resource_v2 c inner join view_resourcerelationship_v2 l on c.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where c.category @> array['config_map', 'Kubernetes']
+                                   and d.category @> array['daemon_set', 'Kubernetes']
+                            )
+                            SELECT
+                            r.ds_name dependent_device_name,
+                            r.ds_device42_id dependent_device_device42_id,
+                            'Contains' as downstream_relationship,
+                            r.cm_name dependency_device_name,
+                            r.cm_device42_id dependency_device_device42_id,
+                            'Contained By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+
+                     UNION
+                     select * from (
+                            WITH k8sres as (
+                            select
+                                   d.resource_name as dp_name,
+                                   r.resource_name as rs_name,
+                                   format('Resource-%s', d.resource_pk) AS dp_device42_id,
+                                   format('Resource-%s', r.resource_pk) AS rs_device42_id,
+                                   r.resource_pk,
+                                   r.cloudinfrastructure_fk
+                            from view_resource_v2 r inner join view_resourcerelationship_v2 l on r.resource_pk = l.to_resource_fk
+                                   inner join view_resource_v2 d on d.resource_pk = l.from_resource_fk
+                            where r.category @> array['replica_set', 'Kubernetes']
+                                   and d.category @> array['deployment', 'Kubernetes']
+                            )
+                            SELECT
+                            r.dp_name dependent_device_name,
+                            r.dp_device42_id dependent_device_device42_id,
+                            'Uses' as downstream_relationship,
+                            r.rs_name dependency_device_name,
+                            r.rs_device42_id dependency_device_device42_id,
+                            'Owned By' as upstream_relationship
+                            FROM
+                                   k8sres r
+                                   inner join view_cloudinfrastructure_v2 i on r.cloudinfrastructure_fk = i.cloudinfrastructure_pk
+                                   inner join view_vendor_v1 v on i.cloud_vendor_fk = v.vendor_pk
+                            WHERE
+                                   v.name = 'Amazon' ) l
+                     UNION
+
+                    SELECT * FROM (
+                        WITH public_ips AS MATERIALIZED (
+                            SELECT
+                                ip.ipaddress_pk,
+                                ip.details ->> 'name' AS ip_name,
+                                ip.details ->> 'port' AS port_id,
+                                host(ip.ip_address) AS ip_host
+                            FROM view_ipaddress_v2 ip
+                            WHERE ip.is_public = TRUE
+                        ),
+                        google_netports AS MATERIALIZED (
+                            SELECT
+                                netport.netport_pk,
+                                netport.port,
+                                netport.details ->> 'nat_ip' AS nat_ip,
+                                coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS display_name
+                            FROM view_netport_v1 netport
+                            JOIN view_cloudinfrastructure_v2 infra
+                                ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                            JOIN view_vendor_v1 vendor
+                                ON infra.cloud_vendor_fk = vendor.vendor_pk
+                            WHERE infra.account_id IS NOT NULL
+                            AND vendor.name = 'Google'
+                        )
+                        SELECT
+                            np.display_name AS dependent_device_name,
+                            format('Netport-%s', np.netport_pk) AS dependent_device_device42_id,
+                            'Has' AS downstream_relationship,
+                            ip.ip_name AS dependency_device_name,
+                            format('IP-%s', ip.ipaddress_pk) AS dependency_device_device42_id,
+                            'Is Attached To' AS upstream_relationship
+                        FROM public_ips ip
+                        INNER JOIN google_netports np
+                            ON np.port = ip.port_id
+                            AND np.nat_ip = ip.ip_host
+                    )
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        COALESCE(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port) AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                    FROM
+                        view_netport_v1 netport
+                    LEFT JOIN
+                        view_device_v2 AS device
+                        ON device.device_pk = netport.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance
+                        ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra
+                        ON netport.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name IS NULL
+                                    OR cloud_instance.instance_name = '' THEN device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END                                                            AS dependent_device_name,
+                        format('Device-%s', device.device_pk)                         AS dependent_device_device42_id,
+                        'Has'                                                         AS downstream_relationship,
+                        ip.details ->> 'name'                                         AS dependency_device_name,
+                        format('IP-%s', ip.ipaddress_pk)                      AS dependency_device_device42_id,
+                        'Is Attached To'                                              AS upstream_relationship
+                     FROM
+                        view_ipaddress_v2 ip
+                    JOIN
+                        view_cloudinfrastructure_v2 infra ON ip.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipd on ipd.ipaddress_fk = ip.ipaddress_pk
+                    INNER JOIN
+                        view_device_v2 device on ipd.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    WHERE
+                        infra.account_id IS NOT NULL
+                        AND ip.is_public = TRUE
+                        AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cloud_instance.instance_name is null or cloud_instance.instance_name = '' then device.name
+                                    ELSE cloud_instance.instance_name
+                                END
+                        END as dependent_device_name,
+                        format('Device-%s', rel.device_fk) as dependent_device_device42_id,
+                        'Has' as downstream_relationship,
+                        resource.resource_name as dependency_device_name,
+                        format('Resource-%s', rel.resource_fk) as dependency_device_device42_id,
+                        'Is Attached To' as upstream_relationship
+                    FROM
+                        view_resource_v2 resource
+                    INNER JOIN
+                        view_deviceresource_v1 rel ON rel.resource_fk = resource.resource_pk
+                    LEFT JOIN
+                        view_device_v2 device ON device.device_pk = rel.device_fk
+                    LEFT JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        resource.category @> ARRAY['GCP', 'disk']
+                        AND vendor.name = 'Google'
+                        AND resource.vendor_resource_type = 'Cloud Disk'
+
+                    union
+
+                    SELECT
+                        CASE
+                           WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                           ELSE
+                              CASE
+                                     WHEN cloud_instance.instance_name IS NULL
+                                     OR     cloud_instance.instance_name = '' THEN device.NAME
+                                     ELSE cloud_instance.instance_name
+                              END
+                        END                                         AS dependent_device_name,
+                        format('Device-%s', device.device_pk)       AS dependent_device_device42_id,
+                        'Provisioned From'                          AS downstream_relationship,
+                        image.resource_name                         AS dependency_device_name,
+                        format('Resource-%s', image.resource_pk)    AS dependency_device_device42_id,
+                        'Provisioned'                               AS upstream_relationship
+                     FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_cloudinstance_v1 cloud_instance ON cloud_instance.device_fk = device.device_pk
+                    INNER JOIN
+                        view_resource_v2 image on cloud_instance.image_id = image.resource_name
+                    LEFT JOIN
+                        view_cloudinfrastructure_v2 infra ON image.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    LEFT JOIN
+                        view_vendor_v1 vendor ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE
+                        image.category @> ARRAY['GCP Image'] AND vendor.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        subnet.name                                 AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)       AS dependent_device_device42_id,
+                        'Contains'                                  AS downstream_relationship,
+                        CASE
+                            WHEN position('/' IN device.name) > 0 THEN
+                                substring(device.name FROM position('/' IN device.name) + 1)
+                            ELSE
+                                CASE
+                                    WHEN cid.instance_name is null or cid.instance_name = '' then device.name
+                                    ELSE cid.instance_name
+                                END
+                        END                                         AS dependency_device_name,
+                        format('Device-%s', device.device_pk)       AS dependency_device_device42_id,
+                        'Contained By'                              AS upstream_relationship
+                    FROM
+                        view_device_v2 device
+                    INNER JOIN
+                        view_netport_v1 netport ON device.device_pk = netport.device_fk
+                    INNER JOIN
+                        view_cloudinstance_v1 cid ON cid.device_fk = device.device_pk
+                    INNER JOIN
+                        view_cloudinfrastructure_v2 ci ON ci.account_id = cid.account
+                    INNER JOIN
+                        view_vendor_v1 v on ci.cloud_vendor_fk = v.vendor_pk
+                    INNER JOIN
+                        view_ipaddress_device_v2 ipr on ipr.device_fk = device.device_pk
+                    INNER JOIN
+                        view_ipaddress_v2 ip on ip.ipaddress_pk = ipr.ipaddress_fk
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN
+                        view_vrfgroup_v1 vrf on vrf.vrfgroup_pk = subnet.vrfgroup_fk
+                    WHERE
+                    v.name = 'Google'
+
+                    union
+
+                    SELECT DISTINCT
+                        coalesce(NULLIF(vrf.vendor_custom_fields -> 'Name', ''), vrf.name) AS dependent_device_name,
+                        format('Subnet-%s', subnet.subnet_pk)                              AS dependent_device_device42_id,
+                        'Contains'                                                         AS downstream_relationship,
+                        coalesce(NULLIF(netport.vendor_custom_fields -> 'Name', ''), netport.port)  AS dependency_device_name,
+                        format('Netport-%s', netport.netport_pk)                        AS dependency_device_device42_id,
+                        'Contained By'                                                  AS upstream_relationship
+                    FROM view_netport_v1 netport
+                    INNER JOIN view_vrfgroup_v1 vrf
+                        ON netport.details->>'network_self_link' = vrf.details->>'self_link'
+                    INNER JOIN view_subnet_v1 subnet
+                        ON netport.details->>'subnet_self_link' = subnet.details->>'self_link'
+                    INNER JOIN view_cloudinfrastructure_v2 infra
+                        ON vrf.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                    INNER JOIN view_vendor_v1 vendor
+                        ON infra.cloud_vendor_fk = vendor.vendor_pk
+                    WHERE vendor.name = 'Google'
+
+                    union
+
+                    SELECT     resource.resource_name                 AS dependent_device_name,
+                            format('Resource-%s', rel.resource_fk) AS dependent_device_device42_id,
+                            'Contains'                             AS downstream_relationship,
+                            CASE
+                                          WHEN position('/' IN device.NAME) > 0 THEN substring(device.NAME FROM position('/' IN device.NAME) + 1)
+                                          ELSE
+                                                 CASE
+                                                               WHEN cloud_instance.instance_name IS NULL
+                                                               OR         cloud_instance.instance_name = '' THEN device.NAME
+                                                               ELSE cloud_instance.instance_name
+                                                 END
+                            END                                AS dependency_device_name,
+                            format('Device-%s', rel.device_fk) AS dependency_device_device42_id,
+                            'Contained By'                     AS upstream_relationship
+                     FROM       view_resource_v2 resource
+                     INNER JOIN view_deviceresource_v1 rel
+                     ON         rel.resource_fk = resource.resource_pk
+                     LEFT JOIN  view_device_v2 device
+                     ON         device.device_pk = rel.device_fk
+                     LEFT JOIN  view_cloudinstance_v1 cloud_instance
+                     ON         cloud_instance.device_fk = device.device_pk
+                     LEFT JOIN  view_cloudinfrastructure_v2 infra
+                     ON         resource.cloudinfrastructure_fk = infra.cloudinfrastructure_pk
+                     LEFT JOIN  view_vendor_v1 vendor
+                     ON         infra.cloud_vendor_fk = vendor.vendor_pk
+                     WHERE      resource.category @> ARRAY['gcp_firewall_rule']
+                     AND        rel.relation = 'Security Group'
+                     AND        vendor.NAME = 'Google'
+
+                     UNION
+
+                     SELECT * FROM (
+                         WITH rels AS MATERIALIZED (
+                            SELECT from_resource_fk, to_resource_fk
+                            FROM  view_resourcerelationship_v2
+                            WHERE  relation = 'datacenter_datastore'
+                         ),
+                         datacenters AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                         ),
+                         datastores AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'ds', 'vcenter']
+                         )
+                         SELECT dc.resource_name                      AS dependent_device_name,
+                               format('Resource-%s', dc.resource_pk)  AS dependent_device_device42_id,
+                               'Contains'                             AS downstream_relationship,
+                               ds.resource_name                       AS dependency_device_name,
+                               format('Resource-%s', ds.resource_pk)  AS dependency_device_device42_id,
+                               'Contained By'                         AS upstream_relationship
+                         FROM   rels
+                         INNER JOIN datacenters dc ON rels.from_resource_fk = dc.resource_pk
+                         INNER JOIN datastores ds  ON rels.to_resource_fk = ds.resource_pk
+                     )
+                     
+                     UNION
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            datacenter.resource_name                         AS dependent_device_name,
+                            format('Resource-%s', datacenter.resource_pk)    AS dependent_device_device42_id,
+                            'Contains'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Contained By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datacenter 
+                            ON rel.resource_fk = datacenter.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'datacenter_device' 
+                            AND datacenter.category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+
+                     SELECT * FROM (
+                         WITH rels AS MATERIALIZED (
+                            SELECT from_resource_fk, to_resource_fk
+                            FROM  view_resourcerelationship_v2
+                            WHERE  relation = 'datacenter_network'
+                         ),
+                         datacenters AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'datacenter', 'vcenter']
+                         ),
+                         networks AS MATERIALIZED (
+                            SELECT resource_pk, resource_name
+                            FROM  view_resource_v2
+                            WHERE  category @> ARRAY['vmware', 'network', 'vcenter']
+                         )
+                         SELECT dc.resource_name                      AS dependent_device_name,
+                               format('Resource-%s', dc.resource_pk)  AS dependent_device_device42_id,
+                               'Contains'                             AS downstream_relationship,
+                               net.resource_name                      AS dependency_device_name,
+                               format('Resource-%s', net.resource_pk) AS dependency_device_device42_id,
+                               'Contained By'                         AS upstream_relationship
+                         FROM   rels
+                         INNER JOIN datacenters dc ON rels.from_resource_fk = dc.resource_pk
+                         INNER JOIN networks net   ON rels.to_resource_fk = net.resource_pk
+                     )
+
+                     UNION 
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Used By'                                        AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Uses'                                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 datastore 
+                            ON rel.resource_fk = datastore.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Mountpoint' 
+                            AND datastore.category @> ARRAY['vmware', 'ds', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT
+                            datastore.resource_name                          AS dependent_device_name,
+                            format('Resource-%s', datastore.resource_pk)     AS dependent_device_device42_id,
+                            'Provides storage for'                           AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Stored on'                                      AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 disk_rel
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON disk_rel.device_fk = device.device_pk
+                     LEFT JOIN
+                            view_resourcerelationship_v2 datastore_rel
+                            ON datastore_rel.from_resource_fk = disk_rel.resource_fk
+                     LEFT JOIN
+                            view_resource_v2 datastore
+                            ON datastore_rel.to_resource_fk = datastore.resource_pk
+                     WHERE 
+                            disk_rel.relation = 'Disk' 
+                            AND datastore_rel.relation = 'disk_data_store'
+                            AND device.type = 'virtual'
+                            AND 'vcenter' = ANY(datastore.category) AND 'ds' = ANY(datastore.category) AND datastore.vendor_resource_type = 'Mountpoint'
+                     UNION
+                     SELECT
+                            virtual_host.name                                AS dependent_device_name,
+                            format('Device-%s', virtual_host.device_pk)      AS dependent_device_device42_id,
+                            'Has Registered'                                 AS downstream_relationship,
+                            virtual_device.name                              AS dependency_device_name,
+                            format('Device-%s', virtual_device.device_pk)    AS dependency_device_device42_id,
+                            'Is Registered On'                               AS upstream_relationship
+                     FROM
+                            view_device_v2 virtual_device
+                     INNER JOIN
+                            view_device_v2 virtual_host
+                            ON virtual_device.virtual_host_device_fk = virtual_host.device_pk
+                     INNER JOIN
+                            view_discoveryscores_v1 score
+                            ON score.device_fk = virtual_host.device_pk      
+                     INNER JOIN 
+                            view_jobscore_v2 jobscore
+                            ON score.jobscore_fk = jobscore.jobscore_pk     
+                     INNER JOIN
+                            view_vserverdiscovery_v1 job
+                            ON jobscore.vserverdiscovery_fk = job.vserverdiscovery_pk
+                     WHERE 
+                            virtual_device.type = 'virtual'
+                            AND job.platform = 'vmware'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Provides'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Provided By'                                    AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'host_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'physical'
+                     UNION
+                     SELECT  
+                            network.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', network.resource_pk)       AS dependent_device_device42_id,
+                            'Connects'                                       AS downstream_relationship,
+                            device.name                                      AS dependency_device_name,
+                            format('Device-%s', device.device_pk)            AS dependency_device_device42_id,
+                            'Connected By'                                   AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 network 
+                            ON rel.resource_fk = network.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'virtual_machine_network' 
+                            AND network.category @> ARRAY['vmware', 'network', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION
+                     SELECT
+                            resource_pool.resource_name                            AS dependent_device_name,
+                            format('Resource-%s', resource_pool.resource_pk)       AS dependent_device_device42_id,
+                            'Defines Resources for'                                AS downstream_relationship,
+                            device.name                                            AS dependency_device_name,
+                            format('Device-%s', device.device_pk)                  AS dependency_device_device42_id,
+                            'Gets Resources from'                                  AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool 
+                            ON rel.resource_fk = resource_pool.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_device' 
+                            AND resource_pool.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                            AND device.type = 'virtual'
+                     UNION 
+                     SELECT
+                            resource_pool_1.resource_name                           AS dependent_device_name,
+                            format('Resource-%s', resource_pool_1.resource_pk)      AS dependent_device_device42_id,
+                            'Contains'                                 AS downstream_relationship,
+                            resource_pool_2.resource_name                           AS dependency_device_name,
+                            format('Resource-%s', resource_pool_2.resource_pk)      AS dependency_device_device42_id,
+                            'Contained By'                                          AS upstream_relationship
+                     FROM
+                            view_resourcerelationship_v2 rel
+                     LEFT JOIN 
+                            view_resource_v2 resource_pool_1 
+                            ON rel.from_resource_fk = resource_pool_1.resource_pk
+                     LEFT JOIN
+                            view_resource_v2 resource_pool_2
+                            ON rel.to_resource_fk = resource_pool_2.resource_pk
+                     WHERE 
+                            rel.relation = 'resource_pool_resource_pool' 
+                            AND resource_pool_1.category @> ARRAY['vmware', 'resource_pool', 'vcenter'] 
+                            AND resource_pool_2.category @> ARRAY['vmware', 'resource_pool', 'vcenter']
+                     UNION 
+                     SELECT
+
+                            device.name                                AS dependent_device_name,
+                            format('Device-%s', device.device_pk)      AS dependent_device_device42_id,
+                            'Has'                                      AS downstream_relationship,
+                            disk.details ->> 'file_name'               AS dependency_device_name,
+                            format('Resource-%s', disk.resource_pk)    AS dependency_device_device42_id,
+                            'Is Attached To'                           AS upstream_relationship
+                     FROM
+                            view_deviceresource_v1 rel
+                     LEFT JOIN 
+                            view_resource_v2 disk 
+                            ON rel.resource_fk = disk.resource_pk
+                     LEFT JOIN
+                            view_device_v2 device
+                            ON rel.device_fk = device.device_pk
+                     WHERE 
+                            rel.relation = 'Disk' 
+                            AND disk.category @> ARRAY['vmware', 'vdisk', 'vcenter']
+                            AND device.type = 'virtual'
+                   "
+                        />
+            </api>
+            <matching>
+                <source-1 device42-id="dependent_device_device42_id"/>
+                <source-2 device42-id="dependency_device_device42_id"/>
+            </matching>
+            <mapping key="dependent_device_name" downstream-relationship="downstream_relationship" upstream-relationship="upstream_relationship" target-key="dependency_device_name">
+            </mapping>
+      </task>
+
+    </tasks>
+</meta>


### PR DESCRIPTION
## Summary

- Convert the **Freshservice Mapping** section index into a real page (`index.mdx`) that lists download links for the `mapping.xml` file for each Cloud Connector version (Version 1.0 through 9.0).
- Add the 9 mapping XML files to `static/assets/files/`.
- Preserve the dot-free `/release-notes/freshservice-mapping/` URL via a `doc`-type category link and `slug` frontmatter.
- Fix the release notes sidebar order: the **Freshservice Mapping** subsection now sorts after **19.06.00 Release** instead of interleaving between release pages (`_category_.yml` position 3 → 5).

## QA

Verified via a browser QA pass on the local build:
- All 9 download links resolve (HTTP 200, `application/xml`) and carry the `download` attribute.
- Each file's internal `<meta version="N.0">` matches its version number, confirming correct file-to-version pairing.
- No console errors; sidebar ordering correct; production build passes.

Ticket: 60871

🤖 Generated with [Claude Code](https://claude.com/claude-code)